### PR TITLE
Jiniya test

### DIFF
--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/controllers/JiraController.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/controllers/JiraController.java
@@ -12,11 +12,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dtcc.workflowmetrics.dataaccess.rest.IssueRESTDAO;
+import com.dtcc.workflowmetrics.entity.MetricsItems;
 import com.dtcc.workflowmetrics.issueObjects.util.IssueConverter;
 import com.dtcc.workflowmetrics.metricsitems.jira.IssueHistory;
 import com.dtcc.workflowmetrics.metricsitems.jira.IssueList;
 import com.dtcc.workflowmetrics.metricsitems.jira.webhook.WebhookData;
-import com.dtcc.workflowmetrics.service.JiraService;
+import com.dtcc.workflowmetrics.service.MetricsItemsDaoService;
+import com.dtcc.workflowmetrics.service.UserHarmonizerService;
 import com.dtcc.workflowmetrics.util.simulator.workflows.WorkflowGenerator;
 
 @CrossOrigin(origins = "*")
@@ -26,15 +28,22 @@ public class JiraController {
     private int counter = 0;
 
     @Autowired
-	private JiraService jiraService;
+	//private JiraService jiraService;
+    private UserHarmonizerService userHarmonizerService;
+    
+    @Autowired
+    private MetricsItemsDaoService metricsItemsDaoService;
 
     @RequestMapping("/jira/addIssue")
     public void jiraMessage(@RequestHeader MultiValueMap<String, String> headers, @RequestBody String inboundBody) {
         System.out.println("Service Invocation " + counter++);
         System.out.println("Data:  " + inboundBody);
+        
         WebhookData issue = IssueConverter.webhookJSONToWebhookData(inboundBody);
 
-        jiraService.addJiraData(issue);
+        MetricsItems metricsItems = userHarmonizerService.harmonizeJira(issue);
+        
+        MetricsItems savedItem = metricsItemsDaoService.save(metricsItems);
         
         System.out.println(issue);
         

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/EventUserCustomFieldDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/EventUserCustomFieldDao.java
@@ -1,0 +1,9 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.EventUserCustomField;
+
+public interface EventUserCustomFieldDao extends CrudRepository<EventUserCustomField, Integer> {
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/EventUserDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/EventUserDao.java
@@ -1,0 +1,9 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.EventUser;
+
+public interface EventUserDao extends CrudRepository<EventUser, Integer>  {
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/EventUserDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/EventUserDao.java
@@ -3,7 +3,10 @@ package com.dtcc.workflowmetrics.dao;
 import org.springframework.data.repository.CrudRepository;
 
 import com.dtcc.workflowmetrics.entity.EventUser;
+import com.dtcc.workflowmetrics.entity.EventUserId;
 
-public interface EventUserDao extends CrudRepository<EventUser, Integer>  {
+public interface EventUserDao extends CrudRepository<EventUser, EventUserId>  {
 
+	boolean existsEventUserByCheckSum(String checksum) ;
+	
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsCustomFieldDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsCustomFieldDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.MetricsItemsCustomField;
+import com.dtcc.workflowmetrics.entity.MetricsItemsCustomFieldId;
+
+public interface MetricsItemsCustomFieldDao extends CrudRepository<MetricsItemsCustomField, MetricsItemsCustomFieldId>{
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.MetricsItems;
+import com.dtcc.workflowmetrics.entity.MetricsItemsId;
+
+public interface MetricsItemsDao extends CrudRepository<MetricsItems, MetricsItemsId> {
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsDao.java
@@ -7,4 +7,6 @@ import com.dtcc.workflowmetrics.entity.MetricsItemsId;
 
 public interface MetricsItemsDao extends CrudRepository<MetricsItems, MetricsItemsId> {
 
+	boolean existsMetricsItemsByCheckSum(String checksum) ;
+
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsStatusDurationDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsStatusDurationDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.MetricsItemsStatusDuration;
+import com.dtcc.workflowmetrics.entity.MetricsItemsStatusDurationId;
+
+public interface MetricsItemsStatusDurationDao extends CrudRepository<MetricsItemsStatusDuration, MetricsItemsStatusDurationId>{
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsStatusTransitionDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsStatusTransitionDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.MetricsItemsStatusTransition;
+import com.dtcc.workflowmetrics.entity.MetricsItemsStatusTransitionId;
+
+public interface MetricsItemsStatusTransitionDao extends CrudRepository<MetricsItemsStatusTransition, MetricsItemsStatusTransitionId>{
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsStatusTransitionDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsStatusTransitionDao.java
@@ -1,5 +1,6 @@
 package com.dtcc.workflowmetrics.dao;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
@@ -11,4 +12,6 @@ public interface MetricsItemsStatusTransitionDao extends CrudRepository<MetricsI
 
 	Optional<MetricsItemsStatusTransition> findByItemIdAndProjectIdAndSourceSystemIdAndToStatus(String itemId, String projectId, int sourceSystemId, String toStatus);
 
+	List<MetricsItemsStatusTransition> findByOrderByTransitionDateDesc();
+	
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsStatusTransitionDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsStatusTransitionDao.java
@@ -1,10 +1,14 @@
 package com.dtcc.workflowmetrics.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.dtcc.workflowmetrics.entity.MetricsItemsStatusTransition;
 import com.dtcc.workflowmetrics.entity.MetricsItemsStatusTransitionId;
 
 public interface MetricsItemsStatusTransitionDao extends CrudRepository<MetricsItemsStatusTransition, MetricsItemsStatusTransitionId>{
+
+	Optional<MetricsItemsStatusTransition> findByItemIdAndProjectIdAndSourceSystemIdAndToStatus(String itemId, String projectId, int sourceSystemId, String toStatus);
 
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsTStatusDurationDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsTStatusDurationDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusDuration;
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusDurationId;
+
+public interface MetricsItemsTStatusDurationDao extends CrudRepository<MetricsItemsTStatusDuration, MetricsItemsTStatusDurationId>{
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsTStatusTransitionDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/MetricsItemsTStatusTransitionDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusTransition;
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusTransitionId;
+
+public interface MetricsItemsTStatusTransitionDao extends CrudRepository<MetricsItemsTStatusTransition, MetricsItemsTStatusTransitionId>{
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/ProjectDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/ProjectDao.java
@@ -2,8 +2,9 @@ package com.dtcc.workflowmetrics.dao;
 
 import org.springframework.data.repository.CrudRepository;
 
-import com.dtcc.workflowmetrics.entity.ProjectDetails;
+import com.dtcc.workflowmetrics.entity.Project;
+import com.dtcc.workflowmetrics.entity.ProjectId;
 
-public interface ProjectDao extends CrudRepository<ProjectDetails, Integer>{
+public interface ProjectDao extends CrudRepository<Project, ProjectId> {
 
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/ProjectDetailsDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/ProjectDetailsDao.java
@@ -1,0 +1,9 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.ProjectDetails;
+
+public interface ProjectDetailsDao extends CrudRepository<ProjectDetails, Integer>{
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/SourceSystemDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/SourceSystemDao.java
@@ -1,0 +1,9 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.SourceSystem;
+
+public interface SourceSystemDao extends CrudRepository<SourceSystem, Integer> {
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusCustomFieldDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusCustomFieldDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.StatusCustomField;
+import com.dtcc.workflowmetrics.entity.StatusCustomFieldId;
+
+public interface StatusCustomFieldDao extends CrudRepository<StatusCustomField, StatusCustomFieldId>{
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.Status;
+import com.dtcc.workflowmetrics.entity.StatusId;
+
+public interface StatusDao extends CrudRepository<Status, StatusId> {
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusDao.java
@@ -1,10 +1,17 @@
 package com.dtcc.workflowmetrics.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.dtcc.workflowmetrics.entity.Status;
 import com.dtcc.workflowmetrics.entity.StatusId;
 
 public interface StatusDao extends CrudRepository<Status, StatusId> {
+
+	boolean existsStatusByCheckSum(String checksum) ;
+	
+	Optional<Status> findByName(String name);
+
 
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusTValueDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusTValueDao.java
@@ -1,0 +1,10 @@
+package com.dtcc.workflowmetrics.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dtcc.workflowmetrics.entity.StatusTValue;
+import com.dtcc.workflowmetrics.entity.StatusTValueId;
+
+public interface StatusTValueDao extends CrudRepository<StatusTValue, StatusTValueId>{
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusTValueDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/StatusTValueDao.java
@@ -7,4 +7,5 @@ import com.dtcc.workflowmetrics.entity.StatusTValueId;
 
 public interface StatusTValueDao extends CrudRepository<StatusTValue, StatusTValueId>{
 
+
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/TransitionDao.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/dao/TransitionDao.java
@@ -1,10 +1,17 @@
 package com.dtcc.workflowmetrics.dao;
 
+import java.util.ArrayList;
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.dtcc.workflowmetrics.entity.Transition;
 
 public interface TransitionDao extends CrudRepository<Transition, Integer>{
 
+	Optional<Transition> findByIssueIDAndToStatus(Integer issueId, String toStatus);
 
+	Optional<Transition> findByIssueIDAndFromStatus(Integer issueId, String fromStatus);
+			
+	ArrayList<Transition> findByIssueID(Integer issueId);
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ChecksumUtil.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ChecksumUtil.java
@@ -4,8 +4,6 @@ import java.security.MessageDigest;
 
 import javax.xml.bind.DatatypeConverter;
 
-import org.springframework.stereotype.Service;
-
 import com.dtcc.workflowmetrics.exception.MetricsLogicException;
 
 public class ChecksumUtil {

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ChecksumUtil.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ChecksumUtil.java
@@ -8,10 +8,9 @@ import org.springframework.stereotype.Service;
 
 import com.dtcc.workflowmetrics.exception.MetricsLogicException;
 
-@Service
 public class ChecksumUtil {
     
-    public String getChecksum(String s) {
+    public static final String getChecksum(String s) {
         StringBuilder sb = new StringBuilder();
         try {
             MessageDigest digest = MessageDigest.getInstance("MD5");
@@ -29,7 +28,7 @@ public class ChecksumUtil {
      * @param hash
      * @return 
      */
-    private String  bytesToHex(byte[] hash) {
+    private static final String bytesToHex(byte[] hash) {
         return DatatypeConverter.printHexBinary(hash).toLowerCase();
     }
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ChecksumUtil.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ChecksumUtil.java
@@ -1,0 +1,35 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.security.MessageDigest;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.springframework.stereotype.Service;
+
+import com.dtcc.workflowmetrics.exception.MetricsLogicException;
+
+@Service
+public class ChecksumUtil {
+    
+    public String getChecksum(String s) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] hash = digest.digest(s.getBytes("UTF-8"));
+            sb.append(bytesToHex(hash));
+        } catch(Exception e) {
+            throw new MetricsLogicException(e);
+        }
+        return sb.toString();
+    }
+    
+    /**
+     * Use javax.xml.bind.DatatypeConverter class in JDK to convert byte array
+     * to a hexadecimal string. Note that this generates hexadecimal in lower case.
+     * @param hash
+     * @return 
+     */
+    private String  bytesToHex(byte[] hash) {
+        return DatatypeConverter.printHexBinary(hash).toLowerCase();
+    }
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ChecksumUtil.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ChecksumUtil.java
@@ -10,6 +10,10 @@ import com.dtcc.workflowmetrics.exception.MetricsLogicException;
 
 public class ChecksumUtil {
     
+    private ChecksumUtil() {
+        
+    }
+    
     public static final String getChecksum(String s) {
         StringBuilder sb = new StringBuilder();
         try {

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUser.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUser.java
@@ -1,0 +1,139 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity(name = "eventUser")
+@Table(name = "EventUser")
+public class EventUser implements Serializable{
+
+		private static final long serialVersionUID = 1L;
+
+		@Id
+		@Column(name = "UserID")
+		private Integer userID;
+
+		@Column(name = "SourceSystem")
+		private String sourceSystem;
+
+		@Column(name = "UserName")
+		private String userName;
+
+		@Column(name = "EmailId")
+		private String emailId;
+
+		@Column(name = "LastUpdateDate")
+		private Long lastUpdateDate;
+
+		public Integer getUserID() {
+			return userID;
+		}
+
+		public void setUserID(Integer userID) {
+			this.userID = userID;
+		}
+
+		public String getSourceSystem() {
+			return sourceSystem;
+		}
+
+		public void setSourceSystem(String sourceSystem) {
+			this.sourceSystem = sourceSystem;
+		}
+
+		public String getUserName() {
+			return userName;
+		}
+
+		public void setUserName(String userName) {
+			this.userName = userName;
+		}
+
+		public String getEmailId() {
+			return emailId;
+		}
+
+		public void setEmailId(String emailId) {
+			this.emailId = emailId;
+		}
+
+		public Long getLastUpdateDate() {
+			return lastUpdateDate;
+		}
+
+		public void setLastUpdateDate(Long lastUpdateDate) {
+			this.lastUpdateDate = lastUpdateDate;
+		}
+
+		public static long getSerialversionuid() {
+			return serialVersionUID;
+		}
+
+		public EventUser(Integer userID, String sourceSystem, String userName, String emailId, Long lastUpdateDate) {
+			super();
+			this.userID = userID;
+			this.sourceSystem = sourceSystem;
+			this.userName = userName;
+			this.emailId = emailId;
+			this.lastUpdateDate = lastUpdateDate;
+		}
+
+		public EventUser() {
+			super();
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((emailId == null) ? 0 : emailId.hashCode());
+			result = prime * result + ((lastUpdateDate == null) ? 0 : lastUpdateDate.hashCode());
+			result = prime * result + ((sourceSystem == null) ? 0 : sourceSystem.hashCode());
+			result = prime * result + ((userID == null) ? 0 : userID.hashCode());
+			result = prime * result + ((userName == null) ? 0 : userName.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			EventUser other = (EventUser) obj;
+			if (emailId == null) {
+				if (other.emailId != null)
+					return false;
+			} else if (!emailId.equals(other.emailId))
+				return false;
+			if (lastUpdateDate == null) {
+				if (other.lastUpdateDate != null)
+					return false;
+			} else if (!lastUpdateDate.equals(other.lastUpdateDate))
+				return false;
+			if (sourceSystem == null) {
+				if (other.sourceSystem != null)
+					return false;
+			} else if (!sourceSystem.equals(other.sourceSystem))
+				return false;
+			if (userID == null) {
+				if (other.userID != null)
+					return false;
+			} else if (!userID.equals(other.userID))
+				return false;
+			if (userName == null) {
+				if (other.userName != null)
+					return false;
+			} else if (!userName.equals(other.userName))
+				return false;
+			return true;
+		}
+
+		
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUser.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUser.java
@@ -12,168 +12,283 @@ import javax.persistence.Table;
 @Entity(name = "eventUser")
 @Table(name = "EventUser")
 @IdClass(EventUserId.class)
-public class EventUser implements Serializable{
+public class EventUser implements Serializable {
 
-		private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-		@Id
-		private String id;
+	@Id
+	private String id;
 
-		@Id
-		@Column(name = "SourceSystem")
-		private int sourceSystem;
+	@Id
+	@Column(name = "SourceSystem")
+	private int sourceSystem;
 
-		@Column(name = "UserName")
-		private String userName;
+	@Column(name = "UserName")
+	private String userName;
 
-		@Column(name = "EmailId")
-		private String emailId;
+	@Column(name = "EmailId")
+	private String emailId;
 
-		@Column(name = "LastUpdateDate")
-		private Long lastUpdateDate;
+	@Column(name = "LastUpdateDate")
+	private Long lastUpdateDate;
 
-		
-		private ArrayList<EventUserCustomField> eventUserCustomField;
-		
-		public ArrayList<EventUserCustomField> addCustomField(EventUserCustomField field){
-			
-			if (null == eventUserCustomField) {
-				eventUserCustomField = new ArrayList<EventUserCustomField>();
-			}
-			
-			if(null!= field) {
-				if(!(field.getUserID().equals(this.getId()))) {
-					throw new RuntimeException("FieldUserId doesnot match");
-				}
-				else {
-					Boolean fieldPresent = false;
-					for (EventUserCustomField f: eventUserCustomField) {
-						if(f.getFieldName().equals(field.getFieldName())) {
-							fieldPresent = true;
-							f.setFieldValue(field.getFieldValue());
-						}
+	@Column(name = "CheckSum", length = 5000)
+	private String checkSum;
+
+	private ArrayList<EventUserCustomField> eventUserCustomField;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public int getSourceSystem() {
+		return sourceSystem;
+	}
+
+	public void setSourceSystem(int sourceSystem) {
+		this.sourceSystem = sourceSystem;
+	}
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public void setUserName(String userName) {
+		this.userName = userName;
+	}
+
+	public String getEmailId() {
+		return emailId;
+	}
+
+	public void setEmailId(String emailId) {
+		this.emailId = emailId;
+	}
+
+	public Long getLastUpdateDate() {
+		return lastUpdateDate;
+	}
+
+	public void setLastUpdateDate(Long lastUpdateDate) {
+		this.lastUpdateDate = lastUpdateDate;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
+	}
+
+	public String getCheckSum() {
+		return checkSum;
+	}
+
+	public void setCheckSum(String checkSum) {
+		this.checkSum = checkSum;
+	}
+
+	public ArrayList<EventUserCustomField> getEventUserCustomField() {
+		return eventUserCustomField;
+	}
+
+	public void setEventUserCustomField(ArrayList<EventUserCustomField> eventUserCustomField) {
+		this.eventUserCustomField = eventUserCustomField;
+	}
+
+	private EventUser(EventUser e) {
+		this.id = e.getId();
+		this.sourceSystem = e.getSourceSystem();
+		this.userName = e.getUserName();
+		this.emailId = e.getEmailId();
+		this.lastUpdateDate = e.getLastUpdateDate();
+		eventUserCustomField = new ArrayList<EventUserCustomField>();
+		for (EventUserCustomField cf : e.getEventUserCustomField()) {
+			eventUserCustomField.add(cf.clone());
+		}
+	}
+
+	public EventUser(String id, int sourceSystem, String userName, String emailId, Long lastUpdateDate,
+			ArrayList<EventUserCustomField> eventUserCustomField, String checkSum) {
+		super();
+		this.id = id;
+		this.sourceSystem = sourceSystem;
+		this.userName = userName;
+		this.emailId = emailId;
+		this.lastUpdateDate = lastUpdateDate;
+		this.eventUserCustomField = eventUserCustomField;
+		this.checkSum = calculateChecksum();
+	}
+
+	public EventUser(String id, int sourceSystem, String userName, String emailId, Long lastUpdateDate,
+			ArrayList<EventUserCustomField> eventUserCustomField) {
+		super();
+		this.id = id;
+		this.sourceSystem = sourceSystem;
+		this.userName = userName;
+		this.emailId = emailId;
+		this.lastUpdateDate = lastUpdateDate;
+		this.eventUserCustomField = eventUserCustomField;
+		this.checkSum = calculateChecksum();
+	}
+
+	public EventUser() {
+	}
+
+	public ArrayList<EventUserCustomField> addCustomField(EventUserCustomField field) {
+
+		if (null == eventUserCustomField) {
+			eventUserCustomField = new ArrayList<EventUserCustomField>();
+		}
+
+		if (null != field) {
+			if (!(field.getUserID().equals(this.getId()))) {
+				throw new RuntimeException("FieldUserId doesnot match");
+			} else {
+				Boolean fieldPresent = false;
+				for (EventUserCustomField f : eventUserCustomField) {
+					if (f.getFieldName().equals(field.getFieldName())) {
+						fieldPresent = true;
+						f.setFieldValue(field.getFieldValue());
 					}
-					
-					if (!fieldPresent) {
-						eventUserCustomField.add(field);
-					}
+				}
+
+				if (!fieldPresent) {
+					eventUserCustomField.add(field);
 				}
 			}
-			
-			return eventUserCustomField;
-		}
-		
-		
-		public ArrayList<EventUserCustomField> getEventUserCustomField() {
-			return eventUserCustomField;
 		}
 
-		public void setEventUserCustomField(ArrayList<EventUserCustomField> eventUserCustomField) {
-			this.eventUserCustomField = eventUserCustomField;
+		return eventUserCustomField;
+	}
+
+	public EventUser clone() {
+		EventUser clone = new EventUser();
+		clone.setId(this.id);
+		clone.setEmailId(this.emailId);
+		clone.setCheckSum(this.checkSum);
+		clone.setSourceSystem(this.sourceSystem);
+		clone.setUserName(this.userName);
+		clone.setLastUpdateDate(this.lastUpdateDate);
+
+		ArrayList<EventUserCustomField> arr = new ArrayList<EventUserCustomField>();
+
+		for (EventUserCustomField e : this.eventUserCustomField) {
+
+			arr.add(new EventUserCustomField(e));
+
 		}
 
-		public String getId() {
-			return id;
-		}
+		clone.setEventUserCustomField(arr);
 
-		public void setId(String id) {
-			this.id = id;
-		}
+		return clone;
+	}
 
-		public int getSourceSystem() {
-			return sourceSystem;
-		}
+	private String calculateChecksum() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(this.toStringWithoutCustomFieldsAndLastUpdateDate());
 
-		public void setSourceSystem(int sourceSystem) {
-			this.sourceSystem = sourceSystem;
+		for (EventUserCustomField f : eventUserCustomField) {
+			sb.append(f.toStringWithoutCreateDate());
 		}
+		return ChecksumUtil.getChecksum(sb.toString());
+	}
 
-		public String getUserName() {
-			return userName;
-		}
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("EventUser [id=");
+		builder.append(id);
+		builder.append(", SourceSystem=");
+		builder.append(sourceSystem);
+		builder.append(", UserName=");
+		builder.append(userName);
+		builder.append(", EmailId=");
+		builder.append(emailId);
+		builder.append(", LastUpdateDate=");
+		builder.append(lastUpdateDate);
+		builder.append(", EventUserCustomField=");
+		builder.append(eventUserCustomField);
+		builder.append(", CheckSum=");
+		builder.append(checkSum);
+		builder.append("]");
+		return builder.toString();
+	}
 
-		public void setUserName(String userName) {
-			this.userName = userName;
-		}
 
-		public String getEmailId() {
-			return emailId;
-		}
+	public String toStringWithoutCustomFieldsAndLastUpdateDate() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("EventUser [id=");
+		builder.append(id);
+		builder.append(", SourceSystem=");
+		builder.append(sourceSystem);
+		builder.append(", UserName=");
+		builder.append(userName);
+		builder.append(", EmailId=");
+		builder.append(emailId);
+		builder.append(", CheckSum=");
+		builder.append(checkSum);
+		builder.append("]");
+		return builder.toString();
+	}
 
-		public void setEmailId(String emailId) {
-			this.emailId = emailId;
-		}
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((checkSum == null) ? 0 : checkSum.hashCode());
+		result = prime * result + ((emailId == null) ? 0 : emailId.hashCode());
+		result = prime * result + ((eventUserCustomField == null) ? 0 : eventUserCustomField.hashCode());
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((lastUpdateDate == null) ? 0 : lastUpdateDate.hashCode());
+		result = prime * result + sourceSystem;
+		result = prime * result + ((userName == null) ? 0 : userName.hashCode());
+		return result;
+	}
 
-		public Long getLastUpdateDate() {
-			return lastUpdateDate;
-		}
-
-		public void setLastUpdateDate(Long lastUpdateDate) {
-			this.lastUpdateDate = lastUpdateDate;
-		}
-
-		public static long getSerialversionuid() {
-			return serialVersionUID;
-		}
-
-		public EventUser(String id, int sourceSystem, String userName, String emailId, Long lastUpdateDate) {
-			super();
-			this.id = id;
-			this.sourceSystem = sourceSystem;
-			this.userName = userName;
-			this.emailId = emailId;
-			this.lastUpdateDate = lastUpdateDate;
-		}
-
-		public EventUser() {
-			super();
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((emailId == null) ? 0 : emailId.hashCode());
-			result = prime * result + ((lastUpdateDate == null) ? 0 : lastUpdateDate.hashCode());
-			result = prime * result + sourceSystem;
-			result = prime * result + ((id == null) ? 0 : id.hashCode());
-			result = prime * result + ((userName == null) ? 0 : userName.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			EventUser other = (EventUser) obj;
-			if (emailId == null) {
-				if (other.emailId != null)
-					return false;
-			} else if (!emailId.equals(other.emailId))
-				return false;
-			if (lastUpdateDate == null) {
-				if (other.lastUpdateDate != null)
-					return false;
-			} else if (!lastUpdateDate.equals(other.lastUpdateDate))
-				return false;
-			if (sourceSystem != other.sourceSystem)
-				return false;
-			if (id == null) {
-				if (other.id != null)
-					return false;
-			} else if (!id.equals(other.id))
-				return false;
-			if (userName == null) {
-				if (other.userName != null)
-					return false;
-			} else if (!userName.equals(other.userName))
-				return false;
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
 			return true;
-		}
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		EventUser other = (EventUser) obj;
+		if (checkSum == null) {
+			if (other.checkSum != null)
+				return false;
+		} else if (!checkSum.equals(other.checkSum))
+			return false;
+		if (emailId == null) {
+			if (other.emailId != null)
+				return false;
+		} else if (!emailId.equals(other.emailId))
+			return false;
+		if (eventUserCustomField == null) {
+			if (other.eventUserCustomField != null)
+				return false;
+		} else if (!eventUserCustomField.equals(other.eventUserCustomField))
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (lastUpdateDate == null) {
+			if (other.lastUpdateDate != null)
+				return false;
+		} else if (!lastUpdateDate.equals(other.lastUpdateDate))
+			return false;
+		if (sourceSystem != other.sourceSystem)
+			return false;
+		if (userName == null) {
+			if (other.userName != null)
+				return false;
+		} else if (!userName.equals(other.userName))
+			return false;
+		return true;
+	}
 
-		
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUser.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUser.java
@@ -1,22 +1,25 @@
 package com.dtcc.workflowmetrics.entity;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.IdClass;
 import javax.persistence.Table;
 
 @Entity(name = "eventUser")
 @Table(name = "EventUser")
+@IdClass(EventUserId.class)
 public class EventUser implements Serializable{
 
 		private static final long serialVersionUID = 1L;
 
 		@Id
-		@Column(name = "UserID")
-		private Integer userID;
+		private String id;
 
+		@Id
 		@Column(name = "SourceSystem")
 		private int sourceSystem;
 
@@ -29,12 +32,52 @@ public class EventUser implements Serializable{
 		@Column(name = "LastUpdateDate")
 		private Long lastUpdateDate;
 
-		public Integer getUserID() {
-			return userID;
+		
+		private ArrayList<EventUserCustomField> eventUserCustomField;
+		
+		public ArrayList<EventUserCustomField> addCustomField(EventUserCustomField field){
+			
+			if (null == eventUserCustomField) {
+				eventUserCustomField = new ArrayList<EventUserCustomField>();
+			}
+			
+			if(null!= field) {
+				if(!(field.getUserID().equals(this.getId()))) {
+					throw new RuntimeException("FieldUserId doesnot match");
+				}
+				else {
+					Boolean fieldPresent = false;
+					for (EventUserCustomField f: eventUserCustomField) {
+						if(f.getFieldName().equals(field.getFieldName())) {
+							fieldPresent = true;
+							f.setFieldValue(field.getFieldValue());
+						}
+					}
+					
+					if (!fieldPresent) {
+						eventUserCustomField.add(field);
+					}
+				}
+			}
+			
+			return eventUserCustomField;
+		}
+		
+		
+		public ArrayList<EventUserCustomField> getEventUserCustomField() {
+			return eventUserCustomField;
 		}
 
-		public void setUserID(Integer userID) {
-			this.userID = userID;
+		public void setEventUserCustomField(ArrayList<EventUserCustomField> eventUserCustomField) {
+			this.eventUserCustomField = eventUserCustomField;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
 		}
 
 		public int getSourceSystem() {
@@ -73,9 +116,9 @@ public class EventUser implements Serializable{
 			return serialVersionUID;
 		}
 
-		public EventUser(Integer userID, int sourceSystem, String userName, String emailId, Long lastUpdateDate) {
+		public EventUser(String id, int sourceSystem, String userName, String emailId, Long lastUpdateDate) {
 			super();
-			this.userID = userID;
+			this.id = id;
 			this.sourceSystem = sourceSystem;
 			this.userName = userName;
 			this.emailId = emailId;
@@ -93,7 +136,7 @@ public class EventUser implements Serializable{
 			result = prime * result + ((emailId == null) ? 0 : emailId.hashCode());
 			result = prime * result + ((lastUpdateDate == null) ? 0 : lastUpdateDate.hashCode());
 			result = prime * result + sourceSystem;
-			result = prime * result + ((userID == null) ? 0 : userID.hashCode());
+			result = prime * result + ((id == null) ? 0 : id.hashCode());
 			result = prime * result + ((userName == null) ? 0 : userName.hashCode());
 			return result;
 		}
@@ -119,10 +162,10 @@ public class EventUser implements Serializable{
 				return false;
 			if (sourceSystem != other.sourceSystem)
 				return false;
-			if (userID == null) {
-				if (other.userID != null)
+			if (id == null) {
+				if (other.id != null)
 					return false;
-			} else if (!userID.equals(other.userID))
+			} else if (!id.equals(other.id))
 				return false;
 			if (userName == null) {
 				if (other.userName != null)

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUser.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUser.java
@@ -18,7 +18,7 @@ public class EventUser implements Serializable{
 		private Integer userID;
 
 		@Column(name = "SourceSystem")
-		private String sourceSystem;
+		private int sourceSystem;
 
 		@Column(name = "UserName")
 		private String userName;
@@ -37,11 +37,11 @@ public class EventUser implements Serializable{
 			this.userID = userID;
 		}
 
-		public String getSourceSystem() {
+		public int getSourceSystem() {
 			return sourceSystem;
 		}
 
-		public void setSourceSystem(String sourceSystem) {
+		public void setSourceSystem(int sourceSystem) {
 			this.sourceSystem = sourceSystem;
 		}
 
@@ -73,7 +73,7 @@ public class EventUser implements Serializable{
 			return serialVersionUID;
 		}
 
-		public EventUser(Integer userID, String sourceSystem, String userName, String emailId, Long lastUpdateDate) {
+		public EventUser(Integer userID, int sourceSystem, String userName, String emailId, Long lastUpdateDate) {
 			super();
 			this.userID = userID;
 			this.sourceSystem = sourceSystem;
@@ -92,7 +92,7 @@ public class EventUser implements Serializable{
 			int result = 1;
 			result = prime * result + ((emailId == null) ? 0 : emailId.hashCode());
 			result = prime * result + ((lastUpdateDate == null) ? 0 : lastUpdateDate.hashCode());
-			result = prime * result + ((sourceSystem == null) ? 0 : sourceSystem.hashCode());
+			result = prime * result + sourceSystem;
 			result = prime * result + ((userID == null) ? 0 : userID.hashCode());
 			result = prime * result + ((userName == null) ? 0 : userName.hashCode());
 			return result;
@@ -117,10 +117,7 @@ public class EventUser implements Serializable{
 					return false;
 			} else if (!lastUpdateDate.equals(other.lastUpdateDate))
 				return false;
-			if (sourceSystem == null) {
-				if (other.sourceSystem != null)
-					return false;
-			} else if (!sourceSystem.equals(other.sourceSystem))
+			if (sourceSystem != other.sourceSystem)
 				return false;
 			if (userID == null) {
 				if (other.userID != null)

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserCustomField.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserCustomField.java
@@ -5,10 +5,12 @@ import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.IdClass;
 import javax.persistence.Table;
 
 @Entity(name = "eventUserCustomField")
 @Table(name = "EventUserCustomField")
+@IdClass(EventUserCustomFieldId.class)
 public class EventUserCustomField implements Serializable{
 	
 	/**
@@ -18,14 +20,17 @@ public class EventUserCustomField implements Serializable{
 
 	@Id
 	@Column(name = "UserID")
-	private Integer userID;
+	private String userID;
 
+	@Id
 	@Column(name = "SourceSystem")
 	private int sourceSystem;
 
+	@Id
 	@Column(name = "CreateDate")
 	private Long createDate;
 
+	@Id
 	@Column(name = "FieldName")
 	private String fieldName;
 
@@ -35,11 +40,11 @@ public class EventUserCustomField implements Serializable{
 	@Column(name = "FieldValue")
 	private String fieldValue;
 
-	public Integer getUserID() {
+	public String getUserID() {
 		return userID;
 	}
 
-	public void setUserID(Integer userID) {
+	public void setUserID(String userID) {
 		this.userID = userID;
 	}
 
@@ -83,7 +88,7 @@ public class EventUserCustomField implements Serializable{
 		this.fieldValue = fieldValue;
 	}
 
-	public EventUserCustomField(Integer userID, int sourceSystem, Long createDate, String fieldName,
+	public EventUserCustomField(String userID, int sourceSystem, Long createDate, String fieldName,
 			String fieldDatatype, String fieldValue) {
 		super();
 		this.userID = userID;

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserCustomField.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserCustomField.java
@@ -1,0 +1,154 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity(name = "eventUserCustomField")
+@Table(name = "EventUserCustomField")
+public class EventUserCustomField implements Serializable{
+	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "UserID")
+	private Integer userID;
+
+	@Column(name = "SourceSystem")
+	private int sourceSystem;
+
+	@Column(name = "CreateDate")
+	private Long createDate;
+
+	@Column(name = "FieldName")
+	private String fieldName;
+
+	@Column(name = "FieldDatatype")
+	private String fieldDatatype;
+
+	@Column(name = "FieldValue")
+	private String fieldValue;
+
+	public Integer getUserID() {
+		return userID;
+	}
+
+	public void setUserID(Integer userID) {
+		this.userID = userID;
+	}
+
+	public int getSourceSystem() {
+		return sourceSystem;
+	}
+
+	public void setSourceSystem(int sourceSystem) {
+		this.sourceSystem = sourceSystem;
+	}
+
+	public Long getCreateDate() {
+		return createDate;
+	}
+
+	public void setCreateDate(Long createDate) {
+		this.createDate = createDate;
+	}
+
+	public String getFieldName() {
+		return fieldName;
+	}
+
+	public void setFieldName(String fieldName) {
+		this.fieldName = fieldName;
+	}
+
+	public String getFieldDatatype() {
+		return fieldDatatype;
+	}
+
+	public void setFieldDatatype(String fieldDatatype) {
+		this.fieldDatatype = fieldDatatype;
+	}
+
+	public String getFieldValue() {
+		return fieldValue;
+	}
+
+	public void setFieldValue(String fieldValue) {
+		this.fieldValue = fieldValue;
+	}
+
+	public EventUserCustomField(Integer userID, int sourceSystem, Long createDate, String fieldName,
+			String fieldDatatype, String fieldValue) {
+		super();
+		this.userID = userID;
+		this.sourceSystem = sourceSystem;
+		this.createDate = createDate;
+		this.fieldName = fieldName;
+		this.fieldDatatype = fieldDatatype;
+		this.fieldValue = fieldValue;
+	}
+
+	public EventUserCustomField() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((createDate == null) ? 0 : createDate.hashCode());
+		result = prime * result + ((fieldDatatype == null) ? 0 : fieldDatatype.hashCode());
+		result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+		result = prime * result + ((fieldValue == null) ? 0 : fieldValue.hashCode());
+		result = prime * result + sourceSystem;
+		result = prime * result + ((userID == null) ? 0 : userID.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		EventUserCustomField other = (EventUserCustomField) obj;
+		if (createDate == null) {
+			if (other.createDate != null)
+				return false;
+		} else if (!createDate.equals(other.createDate))
+			return false;
+		if (fieldDatatype == null) {
+			if (other.fieldDatatype != null)
+				return false;
+		} else if (!fieldDatatype.equals(other.fieldDatatype))
+			return false;
+		if (fieldName == null) {
+			if (other.fieldName != null)
+				return false;
+		} else if (!fieldName.equals(other.fieldName))
+			return false;
+		if (fieldValue == null) {
+			if (other.fieldValue != null)
+				return false;
+		} else if (!fieldValue.equals(other.fieldValue))
+			return false;
+		if (sourceSystem != other.sourceSystem)
+			return false;
+		if (userID == null) {
+			if (other.userID != null)
+				return false;
+		} else if (!userID.equals(other.userID))
+			return false;
+		return true;
+	}
+
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserCustomFieldId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserCustomFieldId.java
@@ -1,0 +1,77 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class EventUserCustomFieldId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String userID;
+	
+	private int sourceSystem;
+	
+	private Long createDate;
+	
+	private String fieldName;
+
+	public EventUserCustomFieldId(String userID, int sourceSystem, Long createDate, String fieldName) {
+		super();
+		this.userID = userID;
+		this.sourceSystem = sourceSystem;
+		this.createDate = createDate;
+		this.fieldName = fieldName;
+	}
+
+	
+	public EventUserCustomFieldId() {
+		super();
+	}
+
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((createDate == null) ? 0 : createDate.hashCode());
+		result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+		result = prime * result + sourceSystem;
+		result = prime * result + ((userID == null) ? 0 : userID.hashCode());
+		return result;
+	}
+
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		EventUserCustomFieldId other = (EventUserCustomFieldId) obj;
+		if (createDate == null) {
+			if (other.createDate != null)
+				return false;
+		} else if (!createDate.equals(other.createDate))
+			return false;
+		if (fieldName == null) {
+			if (other.fieldName != null)
+				return false;
+		} else if (!fieldName.equals(other.fieldName))
+			return false;
+		if (sourceSystem != other.sourceSystem)
+			return false;
+		if (userID == null) {
+			if (other.userID != null)
+				return false;
+		} else if (!userID.equals(other.userID))
+			return false;
+		return true;
+	}
+
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserId.java
@@ -7,27 +7,49 @@ public class EventUserId implements Serializable {
 	/**
 	 * 
 	 */
-	
-	  private static final long serialVersionUID = 1L;
-	  
-	  private String id;
-	  
-	  private int sourceSystem;
-	  
-	  public EventUserId(String id, int sourceSystem) { super(); this.id = id;
-	  this.sourceSystem = sourceSystem; }
-	  
-	  public EventUserId() { super(); }
-	  
-	  @Override public int hashCode() { final int prime = 31; int result = 1;
-	  result = prime * result + ((id == null) ? 0 : id.hashCode()); result = prime
-	  * result + sourceSystem; return result; }
-	  
-	  @Override public boolean equals(Object obj) { if (this == obj) return true;
-	  if (obj == null) return false; if (getClass() != obj.getClass()) return
-	  false; EventUserId other = (EventUserId) obj; if (id == null) { if (other.id
-	  != null) return false; } else if (!id.equals(other.id)) return false; if
-	  (sourceSystem != other.sourceSystem) return false; return true; }
-	  
-	 
+
+	private static final long serialVersionUID = 1L;
+
+	private String id;
+
+	private int sourceSystem;
+
+	public EventUserId(String id, int sourceSystem) {
+		super();
+		this.id = id;
+		this.sourceSystem = sourceSystem;
+	}
+
+	public EventUserId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + sourceSystem;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		EventUserId other = (EventUserId) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (sourceSystem != other.sourceSystem)
+			return false;
+		return true;
+	}
+
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/EventUserId.java
@@ -1,0 +1,33 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class EventUserId implements Serializable {
+
+	/**
+	 * 
+	 */
+	
+	  private static final long serialVersionUID = 1L;
+	  
+	  private String id;
+	  
+	  private int sourceSystem;
+	  
+	  public EventUserId(String id, int sourceSystem) { super(); this.id = id;
+	  this.sourceSystem = sourceSystem; }
+	  
+	  public EventUserId() { super(); }
+	  
+	  @Override public int hashCode() { final int prime = 31; int result = 1;
+	  result = prime * result + ((id == null) ? 0 : id.hashCode()); result = prime
+	  * result + sourceSystem; return result; }
+	  
+	  @Override public boolean equals(Object obj) { if (this == obj) return true;
+	  if (obj == null) return false; if (getClass() != obj.getClass()) return
+	  false; EventUserId other = (EventUserId) obj; if (id == null) { if (other.id
+	  != null) return false; } else if (!id.equals(other.id)) return false; if
+	  (sourceSystem != other.sourceSystem) return false; return true; }
+	  
+	 
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Issue.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Issue.java
@@ -43,7 +43,7 @@ public class Issue implements Serializable {
 	@Column(name = "IssueTypeID", insertable = false, updatable = false)
 	private Integer issueTypeID;
 
-	@JsonBackReference
+//	@JsonBackReference
 	@OneToOne(cascade = CascadeType.MERGE)
 	@JoinColumn(name = "ProjectID", referencedColumnName = "ProjectID")
 	private ProjectDetails projectDetail;

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItems.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItems.java
@@ -1,0 +1,710 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+
+@Entity(name = "metricsItems")
+@Table(name = "MetricsItems")
+@IdClass(MetricsItemsId.class)
+public class MetricsItems implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	private String itemId;
+
+	@Id
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
+
+	@Column(name = "ItemKey")
+	private String itemKey;
+
+	@Column(name = "ProjectId")
+	private String projectId;
+
+	@Column(name = "ItemSummary")
+	private String itemSummary;
+
+	@Column(name = "ItemDescription")
+	private String itemDescription;
+
+	@Column(name = "ItemCreateDate")
+	private Long itemCreateDate;
+
+	@Column(name = "ItemCreator")
+	private String itemCreator;
+
+	@Column(name = "LastUpdateDate")
+	private Long lastUpdateDate;
+
+	@Column(name = "LastUpdateUser")
+	private String lastUpdateUser;
+
+	@Column(name = "CheckSum", length = 5000)
+	private String checkSum;
+
+	private ArrayList<MetricsItemsCustomField> metricsItemsCustomField;
+
+	private ArrayList<MetricsItemsTStatusTransition> metricsItemsTStatusTransition;
+
+	private ArrayList<MetricsItemsStatusTransition> metricsItemsStatusTransition;
+
+	private ArrayList<MetricsItemsStatusDuration> metricsItemsStatusDuration;
+
+	private ArrayList<MetricsItemsTStatusDuration> metricsItemsTStatusDuration;
+
+	public final String getItemId() {
+		return itemId;
+	}
+
+	public final MetricsItems setItemId(String itemId) {
+		this.itemId = itemId;
+		return this;
+	}
+
+	public final int getSourceSystemId() {
+		return sourceSystemId;
+	}
+
+	public final MetricsItems setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
+		
+		return this;
+	}
+
+	public final String getItemKey() {
+		return itemKey;
+	}
+
+	public final MetricsItems setItemKey(String itemKey) {
+		this.itemKey = itemKey;
+		return this;
+	}
+
+	public final String getProjectId() {
+		return projectId;
+	}
+
+	public final MetricsItems setProjectId(String projectId) {
+		this.projectId = projectId;
+		return this;
+	}
+
+	public final String getItemSummary() {
+		return itemSummary;
+	}
+
+	public final MetricsItems setItemSummary(String itemSummary) {
+		this.itemSummary = itemSummary;
+		return this;
+	}
+
+	public final String getItemDescription() {
+		return itemDescription;
+	}
+
+	public final MetricsItems setItemDescription(String itemDescription) {
+		this.itemDescription = itemDescription;
+		return this;
+	}
+
+	public final Long getItemCreateDate() {
+		return itemCreateDate;
+	}
+
+	public final MetricsItems setItemCreateDate(Long itemCreateDate) {
+		this.itemCreateDate = itemCreateDate;
+		return this;
+	}
+
+	public final String getItemCreator() {
+		return itemCreator;
+	}
+
+	public final MetricsItems setItemCreator(String itemCreator) {
+		this.itemCreator = itemCreator;
+		return this;
+	}
+
+	public final Long getLastUpdateDate() {
+		return lastUpdateDate;
+	}
+
+	public final MetricsItems setLastUpdateDate(Long lastUpdateDate) {
+		this.lastUpdateDate = lastUpdateDate;
+		return this;
+	}
+
+	public final String getLastUpdateUser() {
+		return lastUpdateUser;
+	}
+
+	public final MetricsItems setLastUpdateUser(String lastUpdateUser) {
+		this.lastUpdateUser = lastUpdateUser;
+		return this;
+	}
+
+	public final String getCheckSum() {
+		return checkSum;
+	}
+
+	public final MetricsItems setCheckSum(String checkSum) {
+		this.checkSum = checkSum;
+		return this;
+	}
+
+	public final ArrayList<MetricsItemsCustomField> getMetricsItemsCustomField() {
+		return metricsItemsCustomField;
+	}
+
+	public final MetricsItems setMetricsItemsCustomField(ArrayList<MetricsItemsCustomField> metricsItemsCustomField) {
+		this.metricsItemsCustomField = metricsItemsCustomField;
+		return this;
+	}
+
+	public final ArrayList<MetricsItemsTStatusTransition> getMetricsItemsTStatusTransition() {
+		return metricsItemsTStatusTransition;
+	}
+
+	public final MetricsItems setMetricsItemsTStatusTransition(
+			ArrayList<MetricsItemsTStatusTransition> metricsItemsTStatusTransition) {
+		this.metricsItemsTStatusTransition = metricsItemsTStatusTransition;
+		return this;
+	}
+
+	public final ArrayList<MetricsItemsStatusTransition> getMetricsItemsStatusTransition() {
+		return metricsItemsStatusTransition;
+	}
+
+	public final MetricsItems setMetricsItemsStatusTransition(ArrayList<MetricsItemsStatusTransition> metricsItemsStatusTransition) {
+		this.metricsItemsStatusTransition = metricsItemsStatusTransition;
+		return this;
+	}
+
+	public final ArrayList<MetricsItemsStatusDuration> getMetricsItemsStatusDuration() {
+		return metricsItemsStatusDuration;
+	}
+
+	public final MetricsItems setMetricsItemsStatusDuration(ArrayList<MetricsItemsStatusDuration> metricsItemsStatusDuration) {
+		this.metricsItemsStatusDuration = metricsItemsStatusDuration;
+		return this;
+	}
+
+	public final ArrayList<MetricsItemsTStatusDuration> getMetricsItemsTStatusDuration() {
+		return metricsItemsTStatusDuration;
+	}
+
+	public final MetricsItems setMetricsItemsTStatusDuration(ArrayList<MetricsItemsTStatusDuration> metricsItemsTStatusDuration) {
+		this.metricsItemsTStatusDuration = metricsItemsTStatusDuration;
+		return this;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
+	}
+
+	private MetricsItems(MetricsItems m) {
+
+		this.itemId = m.itemId;
+		this.sourceSystemId = m.sourceSystemId;
+		this.itemKey = m.itemKey;
+		this.projectId = m.projectId;
+		this.itemSummary = m.itemSummary;
+		this.itemDescription = m.itemDescription;
+		this.itemCreateDate = m.itemCreateDate;
+		this.itemCreator = m.itemCreator;
+		this.lastUpdateDate = m.lastUpdateDate;
+		this.lastUpdateUser = m.lastUpdateUser;
+		metricsItemsCustomField = new ArrayList<MetricsItemsCustomField>();
+		for (MetricsItemsCustomField cf : m.getMetricsItemsCustomField()) {
+			metricsItemsCustomField.add(cf.clone());
+		}
+		metricsItemsTStatusTransition = new ArrayList<MetricsItemsTStatusTransition>();
+		for (MetricsItemsTStatusTransition st : m.getMetricsItemsTStatusTransition()) {
+			metricsItemsTStatusTransition.add(st.clone());
+		}
+		metricsItemsStatusTransition = new ArrayList<MetricsItemsStatusTransition>();
+		for (MetricsItemsStatusTransition st : m.getMetricsItemsStatusTransition()) {
+			metricsItemsStatusTransition.add(st.clone());
+		}
+		metricsItemsStatusDuration = new ArrayList<MetricsItemsStatusDuration>();
+		for (MetricsItemsStatusDuration sd : m.getMetricsItemsStatusDuration()) {
+			metricsItemsStatusDuration.add(sd.clone());
+		}
+		metricsItemsTStatusDuration = new ArrayList<MetricsItemsTStatusDuration>();
+		for (MetricsItemsTStatusDuration sd : m.getMetricsItemsTStatusDuration()) {
+			metricsItemsTStatusDuration.add(sd.clone());
+		}
+	}
+
+	public MetricsItems(String itemId, int sourceSystemId, String itemKey, String projectId, String itemSummary,
+			String itemDescription, Long itemCreateDate, String itemCreator, Long lastUpdateDate, String lastUpdateUser,
+			String checkSum, ArrayList<MetricsItemsCustomField> metricsItemsCustomField,
+			ArrayList<MetricsItemsTStatusTransition> metricsItemsTStatusTransition,
+			ArrayList<MetricsItemsStatusTransition> metricsItemsStatusTransition,
+			ArrayList<MetricsItemsStatusDuration> metricsItemsStatusDuration,
+			ArrayList<MetricsItemsTStatusDuration> metricsItemsTStatusDuration) {
+		super();
+		this.itemId = itemId;
+		this.sourceSystemId = sourceSystemId;
+		this.itemKey = itemKey;
+		this.projectId = projectId;
+		this.itemSummary = itemSummary;
+		this.itemDescription = itemDescription;
+		this.itemCreateDate = itemCreateDate;
+		this.itemCreator = itemCreator;
+		this.lastUpdateDate = lastUpdateDate;
+		this.lastUpdateUser = lastUpdateUser;
+		this.checkSum = calculateChecksum();
+		this.metricsItemsCustomField = metricsItemsCustomField;
+		this.metricsItemsTStatusTransition = metricsItemsTStatusTransition;
+		this.metricsItemsStatusTransition = metricsItemsStatusTransition;
+		this.metricsItemsStatusDuration = metricsItemsStatusDuration;
+		this.metricsItemsTStatusDuration = metricsItemsTStatusDuration;
+	}
+
+	public MetricsItems(String itemId, int sourceSystemId, String itemKey, String projectId, String itemSummary,
+			String itemDescription, Long itemCreateDate, String itemCreator, Long lastUpdateDate, String lastUpdateUser,
+			ArrayList<MetricsItemsCustomField> metricsItemsCustomField,
+			ArrayList<MetricsItemsTStatusTransition> metricsItemsTStatusTransition,
+			ArrayList<MetricsItemsStatusTransition> metricsItemsStatusTransition,
+			ArrayList<MetricsItemsStatusDuration> metricsItemsStatusDuration,
+			ArrayList<MetricsItemsTStatusDuration> metricsItemsTStatusDuration) {
+		super();
+		this.itemId = itemId;
+		this.sourceSystemId = sourceSystemId;
+		this.itemKey = itemKey;
+		this.projectId = projectId;
+		this.itemSummary = itemSummary;
+		this.itemDescription = itemDescription;
+		this.itemCreateDate = itemCreateDate;
+		this.itemCreator = itemCreator;
+		this.lastUpdateDate = lastUpdateDate;
+		this.lastUpdateUser = lastUpdateUser;
+		this.checkSum = calculateChecksum();
+		this.metricsItemsCustomField = metricsItemsCustomField;
+		this.metricsItemsTStatusTransition = metricsItemsTStatusTransition;
+		this.metricsItemsStatusTransition = metricsItemsStatusTransition;
+		this.metricsItemsStatusDuration = metricsItemsStatusDuration;
+		this.metricsItemsTStatusDuration = metricsItemsTStatusDuration;
+	}
+
+	public MetricsItems() {
+		super();
+	}
+
+	private String calculateChecksum() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(this.toStringWithoutCustomFieldsAndDates());
+
+		for (MetricsItemsCustomField f : metricsItemsCustomField) {
+			sb.append(f.toStringWithoutCreateDate());
+		}
+		for (MetricsItemsTStatusTransition t : metricsItemsTStatusTransition) {
+			sb.append(t.toStringWithoutDate());
+		}
+		for (MetricsItemsStatusTransition t : metricsItemsStatusTransition) {
+			sb.append(t.toStringWithoutDate());
+		}
+		for (MetricsItemsStatusDuration d : metricsItemsStatusDuration) {
+			sb.append(d.toStringWithoutDuration());
+		}
+		for (MetricsItemsTStatusDuration d : metricsItemsTStatusDuration) {
+			sb.append(d.toStringWithoutDuration());
+		}
+		return ChecksumUtil.getChecksum(sb.toString());
+	}
+
+	public MetricsItems clone() {
+		MetricsItems clone = new MetricsItems();
+		clone.setItemId(this.itemId);
+		clone.setSourceSystemId(this.sourceSystemId);
+		clone.setItemKey(this.itemKey);
+		clone.setProjectId(this.projectId);
+		clone.setItemSummary(this.itemSummary);
+		clone.setItemDescription(this.itemDescription);
+		clone.setItemCreateDate(this.itemCreateDate);
+		clone.setItemCreator(this.itemCreator);
+		clone.setLastUpdateDate(this.lastUpdateDate);
+		clone.setLastUpdateUser(this.lastUpdateUser);
+
+		ArrayList<MetricsItemsCustomField> custFldArr = new ArrayList<MetricsItemsCustomField>();
+
+		for (MetricsItemsCustomField e : this.metricsItemsCustomField) {
+
+			custFldArr.add(new MetricsItemsCustomField(e));
+
+		}
+		clone.setMetricsItemsCustomField(custFldArr);
+
+		ArrayList<MetricsItemsTStatusTransition> mTranSrr = new ArrayList<MetricsItemsTStatusTransition>();
+
+		for (MetricsItemsTStatusTransition t : this.metricsItemsTStatusTransition) {
+
+			mTranSrr.add(new MetricsItemsTStatusTransition(t));
+
+		}
+		clone.setMetricsItemsTStatusTransition(mTranSrr);
+		
+		ArrayList<MetricsItemsStatusTransition> tran = new ArrayList<MetricsItemsStatusTransition>();
+
+		for (MetricsItemsStatusTransition t : this.metricsItemsStatusTransition) {
+
+			tran.add(new MetricsItemsStatusTransition(t));
+
+		}
+		clone.setMetricsItemsStatusTransition(tran);
+		
+		ArrayList<MetricsItemsStatusDuration> dur = new ArrayList<MetricsItemsStatusDuration>();
+
+		for (MetricsItemsStatusDuration d : this.metricsItemsStatusDuration) {
+
+			dur.add(new MetricsItemsStatusDuration(d));
+
+		}
+		clone.setMetricsItemsStatusDuration(dur);
+		
+		ArrayList<MetricsItemsTStatusDuration> tDur = new ArrayList<MetricsItemsTStatusDuration>();
+
+		for (MetricsItemsTStatusDuration d : this.metricsItemsTStatusDuration) {
+
+			tDur.add(new MetricsItemsTStatusDuration(d));
+
+		}
+
+		clone.setMetricsItemsTStatusDuration(tDur);
+
+		return clone;
+	}
+	
+	public ArrayList<MetricsItemsCustomField> addCustomField(MetricsItemsCustomField field) {
+
+		if (null == metricsItemsCustomField) {
+			metricsItemsCustomField = new ArrayList<MetricsItemsCustomField>();
+		}
+
+		if (null != field) {
+			if (!(field.getItemId().equals(this.getItemId()))) {
+				throw new RuntimeException("FieldItemId doesnot match");
+			} else {
+				Boolean fieldPresent = false;
+				for (MetricsItemsCustomField f : metricsItemsCustomField) {
+					if (f.getFieldName().equals(field.getFieldName())) {
+						fieldPresent = true;
+						f.setFieldValue(field.getFieldValue());
+					}
+				}
+
+				if (!fieldPresent) {
+					metricsItemsCustomField.add(field);
+				}
+			}
+		}
+
+		return metricsItemsCustomField;
+	}
+
+	public ArrayList<MetricsItemsTStatusTransition> addTStatusTransition(MetricsItemsTStatusTransition trans) {
+
+		if (null == metricsItemsTStatusTransition) {
+			metricsItemsTStatusTransition = new ArrayList<MetricsItemsTStatusTransition>();
+		}
+
+		if (null != trans) {
+			if (!(trans.getItemId().equals(this.getItemId()))) {
+				throw new RuntimeException("FieldItemId doesnot match");
+			} else {
+				Boolean fieldPresent = false;
+				for (MetricsItemsTStatusTransition t : metricsItemsTStatusTransition) {
+					if (t.getStatus() == trans.getStatus()) {
+						fieldPresent = true;
+						t.setStatus(trans.getStatus());
+					}
+				}
+
+				if (!fieldPresent) {
+					metricsItemsTStatusTransition.add(trans);
+				}
+			}
+		}
+
+		return metricsItemsTStatusTransition;
+	}
+
+	public ArrayList<MetricsItemsStatusTransition> addStatusTransition(MetricsItemsStatusTransition sTran) {
+
+		if (null == metricsItemsStatusTransition) {
+			metricsItemsStatusTransition = new ArrayList<MetricsItemsStatusTransition>();
+		}
+
+		if (null != sTran) {
+			if (!(sTran.getItemId().equals(this.getItemId()))) {
+				throw new RuntimeException("FieldItemId doesnot match");
+			} else {
+				Boolean fieldPresent = false;
+				for (MetricsItemsStatusTransition t : metricsItemsStatusTransition) {
+					if ((t.getFromStatus() == sTran.getFromStatus()) && (t.getToStatus() == sTran.getToStatus()))  {
+						fieldPresent = true;
+						t.setFromStatus(sTran.getFromStatus());
+						t.setToStatus(sTran.getToStatus());
+					}
+				}
+
+				if (!fieldPresent) {
+					metricsItemsStatusTransition.add(sTran);
+				}
+			}
+		}
+
+		return metricsItemsStatusTransition;
+	}
+
+	public ArrayList<MetricsItemsStatusDuration> addStatusDuration(MetricsItemsStatusDuration dur) {
+
+		if (null == metricsItemsStatusDuration) {
+			metricsItemsStatusDuration = new ArrayList<MetricsItemsStatusDuration>();
+		}
+
+		if (null != dur) {
+			if (!(dur.getItemId().equals(this.getItemId()))) {
+				throw new RuntimeException("FieldItemId doesnot match");
+			} else {
+				Boolean fieldPresent = false;
+				for (MetricsItemsStatusDuration d : metricsItemsStatusDuration) {
+					if (d.getStatus() == dur.getStatus()) {
+						fieldPresent = true;
+						d.setStatus(dur.getStatus());
+					}
+				}
+
+				if (!fieldPresent) {
+					metricsItemsStatusDuration.add(dur);
+				}
+			}
+		}
+
+		return metricsItemsStatusDuration;
+	}
+
+	public ArrayList<MetricsItemsTStatusDuration> addTStatusDuration(MetricsItemsTStatusDuration tDur) {
+
+		if (null == metricsItemsTStatusDuration) {
+			metricsItemsTStatusDuration = new ArrayList<MetricsItemsTStatusDuration>();
+		}
+
+		if (null != tDur) {
+			if (!(tDur.getItemId().equals(this.getItemId()))) {
+				throw new RuntimeException("FieldItemId doesnot match");
+			} else {
+				Boolean fieldPresent = false;
+				for (MetricsItemsTStatusDuration d : metricsItemsTStatusDuration) {
+					if (d.getStatus() == tDur.getStatus()) {
+						fieldPresent = true;
+						d.setStatus(tDur.getStatus());
+					}
+				}
+
+				if (!fieldPresent) {
+					metricsItemsTStatusDuration.add(tDur);
+				}
+			}
+		}
+
+		return metricsItemsTStatusDuration;
+	}
+
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("MetricsItems [itemId=");
+		builder.append(itemId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", itemKey=");
+		builder.append(itemKey);
+		builder.append(", projectId=");
+		builder.append(projectId);
+		builder.append(", itemSummary=");
+		builder.append(itemSummary);
+		builder.append(", itemDescription=");
+		builder.append(itemDescription);
+		builder.append(", itemSummary=");
+		builder.append(itemSummary);
+		builder.append(", itemCreateDate=");
+		builder.append(itemCreateDate);
+		builder.append(", itemCreator=");
+		builder.append(itemCreator);
+		builder.append(", lastUpdateDate=");
+		builder.append(lastUpdateDate);
+		builder.append(", lastUpdateUser=");
+		builder.append(lastUpdateUser);
+		builder.append(", metricsItemsCustomField=");
+		builder.append(metricsItemsCustomField);
+		builder.append(", metricsItemsTStatusTransition=");
+		builder.append(metricsItemsTStatusTransition);
+		builder.append(", metricsItemsStatusTransition=");
+		builder.append(metricsItemsStatusTransition);
+		builder.append(", metricsItemsStatusDuration=");
+		builder.append(metricsItemsStatusDuration);
+		builder.append(", metricsItemsTStatusDuration=");
+		builder.append(metricsItemsTStatusDuration);
+		builder.append(", CheckSum=");
+		builder.append(checkSum);
+		builder.append("]");
+		return builder.toString();
+	}
+
+	public String toStringWithoutCustomFieldsAndDates() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("MetricsItems [itemId=");
+		builder.append(itemId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", itemKey=");
+		builder.append(itemKey);
+		builder.append(", projectId=");
+		builder.append(projectId);
+		builder.append(", itemSummary=");
+		builder.append(itemSummary);
+		builder.append(", itemDescription=");
+		builder.append(itemDescription);
+		builder.append(", itemSummary=");
+		builder.append(itemSummary);
+		builder.append(", itemCreator=");
+		builder.append(itemCreator);
+		builder.append(", lastUpdateUser=");
+		builder.append(lastUpdateUser);
+		builder.append(", CheckSum=");
+		builder.append(checkSum);
+		builder.append("]");
+		return builder.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((checkSum == null) ? 0 : checkSum.hashCode());
+		result = prime * result + ((itemCreateDate == null) ? 0 : itemCreateDate.hashCode());
+		result = prime * result + ((itemCreator == null) ? 0 : itemCreator.hashCode());
+		result = prime * result + ((itemDescription == null) ? 0 : itemDescription.hashCode());
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((itemKey == null) ? 0 : itemKey.hashCode());
+		result = prime * result + ((itemSummary == null) ? 0 : itemSummary.hashCode());
+		result = prime * result + ((lastUpdateDate == null) ? 0 : lastUpdateDate.hashCode());
+		result = prime * result + ((lastUpdateUser == null) ? 0 : lastUpdateUser.hashCode());
+		result = prime * result + ((metricsItemsCustomField == null) ? 0 : metricsItemsCustomField.hashCode());
+		result = prime * result + ((metricsItemsStatusDuration == null) ? 0 : metricsItemsStatusDuration.hashCode());
+		result = prime * result
+				+ ((metricsItemsStatusTransition == null) ? 0 : metricsItemsStatusTransition.hashCode());
+		result = prime * result + ((metricsItemsTStatusDuration == null) ? 0 : metricsItemsTStatusDuration.hashCode());
+		result = prime * result
+				+ ((metricsItemsTStatusTransition == null) ? 0 : metricsItemsTStatusTransition.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItems other = (MetricsItems) obj;
+		if (checkSum == null) {
+			if (other.checkSum != null)
+				return false;
+		} else if (!checkSum.equals(other.checkSum))
+			return false;
+		if (itemCreateDate == null) {
+			if (other.itemCreateDate != null)
+				return false;
+		} else if (!itemCreateDate.equals(other.itemCreateDate))
+			return false;
+		if (itemCreator == null) {
+			if (other.itemCreator != null)
+				return false;
+		} else if (!itemCreator.equals(other.itemCreator))
+			return false;
+		if (itemDescription == null) {
+			if (other.itemDescription != null)
+				return false;
+		} else if (!itemDescription.equals(other.itemDescription))
+			return false;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (itemKey == null) {
+			if (other.itemKey != null)
+				return false;
+		} else if (!itemKey.equals(other.itemKey))
+			return false;
+		if (itemSummary == null) {
+			if (other.itemSummary != null)
+				return false;
+		} else if (!itemSummary.equals(other.itemSummary))
+			return false;
+		if (lastUpdateDate == null) {
+			if (other.lastUpdateDate != null)
+				return false;
+		} else if (!lastUpdateDate.equals(other.lastUpdateDate))
+			return false;
+		if (lastUpdateUser == null) {
+			if (other.lastUpdateUser != null)
+				return false;
+		} else if (!lastUpdateUser.equals(other.lastUpdateUser))
+			return false;
+		if (metricsItemsCustomField == null) {
+			if (other.metricsItemsCustomField != null)
+				return false;
+		} else if (!metricsItemsCustomField.equals(other.metricsItemsCustomField))
+			return false;
+		if (metricsItemsStatusDuration == null) {
+			if (other.metricsItemsStatusDuration != null)
+				return false;
+		} else if (!metricsItemsStatusDuration.equals(other.metricsItemsStatusDuration))
+			return false;
+		if (metricsItemsStatusTransition == null) {
+			if (other.metricsItemsStatusTransition != null)
+				return false;
+		} else if (!metricsItemsStatusTransition.equals(other.metricsItemsStatusTransition))
+			return false;
+		if (metricsItemsTStatusDuration == null) {
+			if (other.metricsItemsTStatusDuration != null)
+				return false;
+		} else if (!metricsItemsTStatusDuration.equals(other.metricsItemsTStatusDuration))
+			return false;
+		if (metricsItemsTStatusTransition == null) {
+			if (other.metricsItemsTStatusTransition != null)
+				return false;
+		} else if (!metricsItemsTStatusTransition.equals(other.metricsItemsTStatusTransition))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItems.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItems.java
@@ -9,7 +9,6 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
 
-
 @Entity(name = "metricsItems")
 @Table(name = "MetricsItems")
 @IdClass(MetricsItemsId.class)
@@ -79,7 +78,7 @@ public class MetricsItems implements Serializable {
 
 	public final MetricsItems setSourceSystemId(int sourceSystemId) {
 		this.sourceSystemId = sourceSystemId;
-		
+
 		return this;
 	}
 
@@ -187,7 +186,8 @@ public class MetricsItems implements Serializable {
 		return metricsItemsStatusTransition;
 	}
 
-	public final MetricsItems setMetricsItemsStatusTransition(ArrayList<MetricsItemsStatusTransition> metricsItemsStatusTransition) {
+	public final MetricsItems setMetricsItemsStatusTransition(
+			ArrayList<MetricsItemsStatusTransition> metricsItemsStatusTransition) {
 		this.metricsItemsStatusTransition = metricsItemsStatusTransition;
 		return this;
 	}
@@ -196,7 +196,8 @@ public class MetricsItems implements Serializable {
 		return metricsItemsStatusDuration;
 	}
 
-	public final MetricsItems setMetricsItemsStatusDuration(ArrayList<MetricsItemsStatusDuration> metricsItemsStatusDuration) {
+	public final MetricsItems setMetricsItemsStatusDuration(
+			ArrayList<MetricsItemsStatusDuration> metricsItemsStatusDuration) {
 		this.metricsItemsStatusDuration = metricsItemsStatusDuration;
 		return this;
 	}
@@ -205,7 +206,8 @@ public class MetricsItems implements Serializable {
 		return metricsItemsTStatusDuration;
 	}
 
-	public final MetricsItems setMetricsItemsTStatusDuration(ArrayList<MetricsItemsTStatusDuration> metricsItemsTStatusDuration) {
+	public final MetricsItems setMetricsItemsTStatusDuration(
+			ArrayList<MetricsItemsTStatusDuration> metricsItemsTStatusDuration) {
 		this.metricsItemsTStatusDuration = metricsItemsTStatusDuration;
 		return this;
 	}
@@ -339,6 +341,7 @@ public class MetricsItems implements Serializable {
 		clone.setLastUpdateDate(this.lastUpdateDate);
 		clone.setLastUpdateUser(this.lastUpdateUser);
 
+		
 		ArrayList<MetricsItemsCustomField> custFldArr = new ArrayList<MetricsItemsCustomField>();
 
 		for (MetricsItemsCustomField e : this.metricsItemsCustomField) {
@@ -347,6 +350,7 @@ public class MetricsItems implements Serializable {
 
 		}
 		clone.setMetricsItemsCustomField(custFldArr);
+		
 
 		ArrayList<MetricsItemsTStatusTransition> mTranSrr = new ArrayList<MetricsItemsTStatusTransition>();
 
@@ -356,7 +360,7 @@ public class MetricsItems implements Serializable {
 
 		}
 		clone.setMetricsItemsTStatusTransition(mTranSrr);
-		
+
 		ArrayList<MetricsItemsStatusTransition> tran = new ArrayList<MetricsItemsStatusTransition>();
 
 		for (MetricsItemsStatusTransition t : this.metricsItemsStatusTransition) {
@@ -365,29 +369,35 @@ public class MetricsItems implements Serializable {
 
 		}
 		clone.setMetricsItemsStatusTransition(tran);
-		
-		ArrayList<MetricsItemsStatusDuration> dur = new ArrayList<MetricsItemsStatusDuration>();
 
-		for (MetricsItemsStatusDuration d : this.metricsItemsStatusDuration) {
+		if (this.metricsItemsStatusDuration != null) {
 
-			dur.add(new MetricsItemsStatusDuration(d));
+			ArrayList<MetricsItemsStatusDuration> dur = new ArrayList<MetricsItemsStatusDuration>();
 
-		}
-		clone.setMetricsItemsStatusDuration(dur);
-		
-		ArrayList<MetricsItemsTStatusDuration> tDur = new ArrayList<MetricsItemsTStatusDuration>();
+			for (MetricsItemsStatusDuration d : this.metricsItemsStatusDuration) {
 
-		for (MetricsItemsTStatusDuration d : this.metricsItemsTStatusDuration) {
+				dur.add(new MetricsItemsStatusDuration(d));
 
-			tDur.add(new MetricsItemsTStatusDuration(d));
-
+			}
+			clone.setMetricsItemsStatusDuration(dur);
 		}
 
-		clone.setMetricsItemsTStatusDuration(tDur);
+		if (this.metricsItemsTStatusDuration != null) {
+
+			ArrayList<MetricsItemsTStatusDuration> tDur = new ArrayList<MetricsItemsTStatusDuration>();
+
+			for (MetricsItemsTStatusDuration d : this.metricsItemsTStatusDuration) {
+
+				tDur.add(new MetricsItemsTStatusDuration(d));
+
+			}
+
+			clone.setMetricsItemsTStatusDuration(tDur);
+		}
 
 		return clone;
 	}
-	
+
 	public ArrayList<MetricsItemsCustomField> addCustomField(MetricsItemsCustomField field) {
 
 		if (null == metricsItemsCustomField) {
@@ -454,7 +464,7 @@ public class MetricsItems implements Serializable {
 			} else {
 				Boolean fieldPresent = false;
 				for (MetricsItemsStatusTransition t : metricsItemsStatusTransition) {
-					if ((t.getFromStatus() == sTran.getFromStatus()) && (t.getToStatus() == sTran.getToStatus()))  {
+					if ((t.getFromStatus() == sTran.getFromStatus()) && (t.getToStatus() == sTran.getToStatus())) {
 						fieldPresent = true;
 						t.setFromStatus(sTran.getFromStatus());
 						t.setToStatus(sTran.getToStatus());
@@ -523,7 +533,6 @@ public class MetricsItems implements Serializable {
 
 		return metricsItemsTStatusDuration;
 	}
-
 
 	@Override
 	public String toString() {
@@ -706,5 +715,4 @@ public class MetricsItems implements Serializable {
 		return true;
 	}
 
-	
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsCustomField.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsCustomField.java
@@ -1,5 +1,7 @@
 package com.dtcc.workflowmetrics.entity;
 
+import java.io.Serializable;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -9,7 +11,12 @@ import javax.persistence.Table;
 @Entity(name = "metricsItemsCustomField")
 @Table(name = "MetricsItemsCustomField")
 @IdClass(MetricsItemsCustomFieldId.class)
-public class MetricsItemsCustomField {
+public class MetricsItemsCustomField implements Serializable{
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
 
 	@Id
 	@Column(name = "ItemId")
@@ -30,7 +37,7 @@ public class MetricsItemsCustomField {
 	@Column(name = "FieldDatatype")
 	private String fieldDatatype;
 
-	@Column(name = "FieldValue")
+	@Column(name = "FieldValue", length = 5000)
 	private String fieldValue;
 
 	public String getItemId() {

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsCustomField.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsCustomField.java
@@ -1,30 +1,23 @@
 package com.dtcc.workflowmetrics.entity;
 
-import java.io.Serializable;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
 
-@Entity(name = "eventUserCustomField")
-@Table(name = "EventUserCustomField")
-@IdClass(EventUserCustomFieldId.class)
-public class EventUserCustomField implements Serializable {
-
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
+@Entity(name = "metricsItemsCustomField")
+@Table(name = "MetricsItemsCustomField")
+@IdClass(MetricsItemsCustomFieldId.class)
+public class MetricsItemsCustomField {
 
 	@Id
-	@Column(name = "UserID")
-	private String userID;
+	@Column(name = "ItemId")
+	private String itemId;
 
 	@Id
-	@Column(name = "SourceSystem")
-	private int sourceSystem;
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
 
 	@Id
 	@Column(name = "CreateDate")
@@ -40,20 +33,20 @@ public class EventUserCustomField implements Serializable {
 	@Column(name = "FieldValue")
 	private String fieldValue;
 
-	public String getUserID() {
-		return userID;
+	public String getItemId() {
+		return itemId;
 	}
 
-	public void setUserID(String userID) {
-		this.userID = userID;
+	public void setItemId(String itemId) {
+		this.itemId = itemId;
 	}
 
-	public int getSourceSystem() {
-		return sourceSystem;
+	public int getSourceSystemId() {
+		return sourceSystemId;
 	}
 
-	public void setSourceSystem(int sourceSystem) {
-		this.sourceSystem = sourceSystem;
+	public void setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
 	}
 
 	public Long getCreateDate() {
@@ -88,40 +81,42 @@ public class EventUserCustomField implements Serializable {
 		this.fieldValue = fieldValue;
 	}
 
-	public EventUserCustomField(String userID, int sourceSystem, Long createDate, String fieldName,
+
+	public MetricsItemsCustomField(String itemId, int sourceSystemId, Long createDate, String fieldName,
 			String fieldDatatype, String fieldValue) {
 		super();
-		this.userID = userID;
-		this.sourceSystem = sourceSystem;
+		this.itemId = itemId;
+		this.sourceSystemId = sourceSystemId;
 		this.createDate = createDate;
 		this.fieldName = fieldName;
 		this.fieldDatatype = fieldDatatype;
 		this.fieldValue = fieldValue;
 	}
 
-	public EventUserCustomField() {
+	
+	public MetricsItemsCustomField() {
 		super();
 	}
 
-	public EventUserCustomField(EventUserCustomField e) {
-		this.userID = e.userID;
-		this.sourceSystem = e.sourceSystem;
-		this.createDate = e.createDate;
-		this.fieldName = e.fieldName;
-		this.fieldDatatype = e.fieldDatatype;
-		this.fieldValue = e.fieldValue;
-	}
+	public MetricsItemsCustomField(MetricsItemsCustomField cf) {
+		this.itemId = cf.itemId;
+		this.sourceSystemId = cf.sourceSystemId;
+		this.createDate = cf.createDate;
+		this.fieldName = cf.fieldName;
+		this.fieldDatatype = cf.fieldDatatype;
+		this.fieldValue = cf.fieldValue;
+    }
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
 		result = prime * result + ((createDate == null) ? 0 : createDate.hashCode());
 		result = prime * result + ((fieldDatatype == null) ? 0 : fieldDatatype.hashCode());
 		result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
 		result = prime * result + ((fieldValue == null) ? 0 : fieldValue.hashCode());
-		result = prime * result + sourceSystem;
-		result = prime * result + ((userID == null) ? 0 : userID.hashCode());
+		result = prime * result + sourceSystemId;
 		return result;
 	}
 
@@ -133,7 +128,12 @@ public class EventUserCustomField implements Serializable {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		EventUserCustomField other = (EventUserCustomField) obj;
+		MetricsItemsCustomField other = (MetricsItemsCustomField) obj;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
 		if (createDate == null) {
 			if (other.createDate != null)
 				return false;
@@ -154,26 +154,20 @@ public class EventUserCustomField implements Serializable {
 				return false;
 		} else if (!fieldValue.equals(other.fieldValue))
 			return false;
-		if (sourceSystem != other.sourceSystem)
-			return false;
-		if (userID == null) {
-			if (other.userID != null)
-				return false;
-		} else if (!userID.equals(other.userID))
+		if (sourceSystemId != other.sourceSystemId)
 			return false;
 		return true;
 	}
 
-    public EventUserCustomField clone() {
-        return new EventUserCustomField(this);
-    }
-    
-    public String toStringWithoutCreateDate() {
+    @Override
+    public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append("EventUserCustomField [userID=");
-        builder.append(userID);
-        builder.append(", sourceSystem=");
-        builder.append(sourceSystem);
+        builder.append("MetricsItemsCustomField [itemId=");
+        builder.append(itemId);
+        builder.append(", sourceSystemId=");
+        builder.append(sourceSystemId);
+        builder.append(", createDate=");
+        builder.append(createDate);
         builder.append(", fieldName=");
         builder.append(fieldName);
         builder.append(", fieldDatatype=");
@@ -183,6 +177,25 @@ public class EventUserCustomField implements Serializable {
         builder.append("]");
         return builder.toString();
     }
-  
+
+    public String toStringWithoutCreateDate() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("MetricsItemsCustomField [itemId=");
+        builder.append(itemId);
+        builder.append(", sourceSystemId=");
+        builder.append(sourceSystemId);
+        builder.append(", fieldName=");
+        builder.append(fieldName);
+        builder.append(", fieldDatatype=");
+        builder.append(fieldDatatype);
+        builder.append(", fieldValue=");
+        builder.append(fieldValue);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    public MetricsItemsCustomField clone() {
+        return new MetricsItemsCustomField(this);
+    }
 
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsCustomFieldId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsCustomFieldId.java
@@ -1,0 +1,74 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class MetricsItemsCustomFieldId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String itemId;
+
+	private int sourceSystemId;
+
+	private Long createDate;
+
+	private String fieldName;
+
+	public MetricsItemsCustomFieldId(String itemId, int sourceSystemId, Long createDate, String fieldName) {
+		super();
+		this.itemId = itemId;
+		this.sourceSystemId = sourceSystemId;
+		this.createDate = createDate;
+		this.fieldName = fieldName;
+	}
+
+	public MetricsItemsCustomFieldId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((createDate == null) ? 0 : createDate.hashCode());
+		result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + sourceSystemId;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsCustomFieldId other = (MetricsItemsCustomFieldId) obj;
+		if (createDate == null) {
+			if (other.createDate != null)
+				return false;
+		} else if (!createDate.equals(other.createDate))
+			return false;
+		if (fieldName == null) {
+			if (other.fieldName != null)
+				return false;
+		} else if (!fieldName.equals(other.fieldName))
+			return false;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		return true;
+	}
+	
+	
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsId.java
@@ -1,0 +1,55 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class MetricsItemsId implements Serializable{
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String itemId;
+
+	private int sourceSystemId;
+
+	public MetricsItemsId(String itemId, int sourceSystemId) {
+		super();
+		this.itemId = itemId;
+		this.sourceSystemId = sourceSystemId;
+	}
+
+	public MetricsItemsId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + sourceSystemId;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsId other = (MetricsItemsId) obj;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusDuration.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusDuration.java
@@ -32,7 +32,7 @@ public class MetricsItemsStatusDuration implements Serializable {
 
 	@Id
 	@Column(name = "Status")
-	private int status;
+	private String status;
 
 	@Column(name = "Duration")
 	private Long duration;
@@ -61,11 +61,11 @@ public class MetricsItemsStatusDuration implements Serializable {
 		this.sourceSystemId = sourceSystemId;
 	}
 
-	public int getStatus() {
+	public String getStatus() {
 		return status;
 	}
 
-	public void setStatus(int status) {
+	public void setStatus(String status) {
 		this.status = status;
 	}
 
@@ -81,7 +81,7 @@ public class MetricsItemsStatusDuration implements Serializable {
 		return serialVersionUID;
 	}
 
-	public MetricsItemsStatusDuration(String itemId, String projectId, int sourceSystemId, int status, Long duration) {
+	public MetricsItemsStatusDuration(String itemId, String projectId, int sourceSystemId, String status, Long duration) {
 		super();
 		this.itemId = itemId;
 		this.projectId = projectId;
@@ -111,7 +111,7 @@ public class MetricsItemsStatusDuration implements Serializable {
 		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
 		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
 		result = prime * result + sourceSystemId;
-		result = prime * result + status;
+		result = prime * result + ((status == null) ? 0 : status.hashCode());
 		return result;
 	}
 
@@ -141,7 +141,10 @@ public class MetricsItemsStatusDuration implements Serializable {
 			return false;
 		if (sourceSystemId != other.sourceSystemId)
 			return false;
-		if (status != other.status)
+		if (status == null) {
+			if (other.status != null)
+				return false;
+		} else if (!status.equals(other.status))
 			return false;
 		return true;
 	}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusDuration.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusDuration.java
@@ -1,0 +1,182 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+@Entity(name = "metricsItemsStatusDuration")
+@Table(name = "MetricsItemsStatusDuration")
+@IdClass(MetricsItemsStatusDurationId.class)
+public class MetricsItemsStatusDuration implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "ItemId")
+	private String itemId;
+
+	@Id
+	@Column(name = "ProjectId")
+	private String projectId;
+
+	@Id
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
+
+	@Id
+	@Column(name = "Status")
+	private int status;
+
+	@Column(name = "Duration")
+	private Long duration;
+
+	public String getItemId() {
+		return itemId;
+	}
+
+	public void setItemId(String itemId) {
+		this.itemId = itemId;
+	}
+
+	public String getProjectId() {
+		return projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	public int getSourceSystemId() {
+		return sourceSystemId;
+	}
+
+	public void setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
+	}
+
+	public int getStatus() {
+		return status;
+	}
+
+	public void setStatus(int status) {
+		this.status = status;
+	}
+
+	public Long getDuration() {
+		return duration;
+	}
+
+	public void setDuration(Long duration) {
+		this.duration = duration;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
+	}
+
+	public MetricsItemsStatusDuration(String itemId, String projectId, int sourceSystemId, int status, Long duration) {
+		super();
+		this.itemId = itemId;
+		this.projectId = projectId;
+		this.sourceSystemId = sourceSystemId;
+		this.status = status;
+		this.duration = duration;
+	}
+
+	public MetricsItemsStatusDuration() {
+		super();
+	}
+	
+	public MetricsItemsStatusDuration(MetricsItemsStatusDuration sd) {
+		super();
+		this.itemId = sd.itemId;
+		this.projectId = sd.projectId;
+		this.sourceSystemId = sd.sourceSystemId;
+		this.status = sd.status;
+		this.duration = sd.duration;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((duration == null) ? 0 : duration.hashCode());
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + status;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsStatusDuration other = (MetricsItemsStatusDuration) obj;
+		if (duration == null) {
+			if (other.duration != null)
+				return false;
+		} else if (!duration.equals(other.duration))
+			return false;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (status != other.status)
+			return false;
+		return true;
+	}
+	
+	   @Override
+	    public String toString() {
+	        StringBuilder builder = new StringBuilder();
+	        builder.append("MetricsItemsStatusDuration [itemId=");
+	        builder.append(itemId);
+	        builder.append(", ProjectId=");
+	        builder.append(projectId);
+	        builder.append(", sourceSystemId=");
+	        builder.append(sourceSystemId);
+	        builder.append(", status=");
+	        builder.append(status);
+	        builder.append(", duration=");
+	        builder.append(duration);
+	        return builder.toString();
+	    }
+
+	    public String toStringWithoutDuration() {
+	        StringBuilder builder = new StringBuilder();
+	        builder.append("MetricsItemsStatusDuration [itemId=");
+	        builder.append(itemId);
+	        builder.append(", ProjectId=");
+	        builder.append(projectId);
+	        builder.append(", sourceSystemId=");
+	        builder.append(sourceSystemId);
+	        builder.append(", status=");
+	        builder.append(status);
+	        return builder.toString();
+	    }
+
+	    public MetricsItemsStatusDuration clone() {
+	        return new MetricsItemsStatusDuration(this);
+	    }
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusDurationId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusDurationId.java
@@ -1,0 +1,70 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class MetricsItemsStatusDurationId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String itemId;
+
+	private String projectId;
+
+	private int sourceSystemId;
+
+	private int status;
+
+	public MetricsItemsStatusDurationId(String itemId, String projectId, int sourceSystemId, int status) {
+		super();
+		this.itemId = itemId;
+		this.projectId = projectId;
+		this.sourceSystemId = sourceSystemId;
+		this.status = status;
+	}
+
+	public MetricsItemsStatusDurationId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + status;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsStatusDurationId other = (MetricsItemsStatusDurationId) obj;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (status != other.status)
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusDurationId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusDurationId.java
@@ -15,9 +15,9 @@ public class MetricsItemsStatusDurationId implements Serializable {
 
 	private int sourceSystemId;
 
-	private int status;
+	private String status;
 
-	public MetricsItemsStatusDurationId(String itemId, String projectId, int sourceSystemId, int status) {
+	public MetricsItemsStatusDurationId(String itemId, String projectId, int sourceSystemId, String status) {
 		super();
 		this.itemId = itemId;
 		this.projectId = projectId;
@@ -36,7 +36,7 @@ public class MetricsItemsStatusDurationId implements Serializable {
 		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
 		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
 		result = prime * result + sourceSystemId;
-		result = prime * result + status;
+		result = prime * result + ((status == null) ? 0 : status.hashCode());
 		return result;
 	}
 

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusTransition.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusTransition.java
@@ -1,0 +1,204 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+@Entity(name = "metricsItemsStatusTransition")
+@Table(name = "MetricsItemsStatusTransition")
+@IdClass(MetricsItemsStatusTransitionId.class)
+public class MetricsItemsStatusTransition implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "ItemId")
+	private String itemId;
+
+	@Id
+	@Column(name = "ProjectId")
+	private String projectId;
+
+	@Id
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
+
+	@Id
+	@Column(name = "FromStatus")
+	private int fromStatus;
+
+	@Id
+	@Column(name = "ToStatus")
+	private int toStatus;
+
+	@Column(name = "TransitionDate")
+	private Long transitionDate;
+
+	public String getItemId() {
+		return itemId;
+	}
+
+	public void setItemId(String itemId) {
+		this.itemId = itemId;
+	}
+
+	public String getProjectId() {
+		return projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	public int getSourceSystemId() {
+		return sourceSystemId;
+	}
+
+	public void setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
+	}
+
+	public int getFromStatus() {
+		return fromStatus;
+	}
+
+	public void setFromStatus(int fromStatus) {
+		this.fromStatus = fromStatus;
+	}
+
+	public int getToStatus() {
+		return toStatus;
+	}
+
+	public void setToStatus(int toStatus) {
+		this.toStatus = toStatus;
+	}
+
+	public Long getTransitionDate() {
+		return transitionDate;
+	}
+
+	public void setTransitionDate(Long transitionDate) {
+		this.transitionDate = transitionDate;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
+	}
+
+	public MetricsItemsStatusTransition(String itemId, String projectId, int sourceSystemId, int fromStatus,
+			int toStatus, Long transitionDate) {
+		super();
+		this.itemId = itemId;
+		this.projectId = projectId;
+		this.sourceSystemId = sourceSystemId;
+		this.fromStatus = fromStatus;
+		this.toStatus = toStatus;
+		this.transitionDate = transitionDate;
+	}
+
+	public MetricsItemsStatusTransition() {
+		super();
+	}
+
+	public MetricsItemsStatusTransition(MetricsItemsStatusTransition st) {
+		super();
+		this.itemId = st.itemId;
+		this.projectId = st.projectId;
+		this.sourceSystemId = st.sourceSystemId;
+		this.fromStatus = st.fromStatus;
+		this.toStatus = st.toStatus;
+		this.transitionDate = st.transitionDate;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + fromStatus;
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + toStatus;
+		result = prime * result + ((transitionDate == null) ? 0 : transitionDate.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsStatusTransition other = (MetricsItemsStatusTransition) obj;
+		if (fromStatus != other.fromStatus)
+			return false;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (toStatus != other.toStatus)
+			return false;
+		if (transitionDate == null) {
+			if (other.transitionDate != null)
+				return false;
+		} else if (!transitionDate.equals(other.transitionDate))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("MetricsItemsTStatusTransition [itemId=");
+		builder.append(itemId);
+		builder.append(", ProjectId=");
+		builder.append(projectId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", fromStatus=");
+		builder.append(fromStatus);
+		builder.append(", toStatus=");
+		builder.append(toStatus);
+		builder.append(", transitionDate=");
+		builder.append(transitionDate);
+		return builder.toString();
+	}
+
+	public String toStringWithoutDate() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("MetricsItemsTStatusTransition [itemId=");
+		builder.append(itemId);
+		builder.append(", ProjectId=");
+		builder.append(projectId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", fromStatus=");
+		builder.append(fromStatus);
+		builder.append(", toStatus=");
+		builder.append(toStatus);
+		return builder.toString();
+	}
+
+	public MetricsItemsStatusTransition clone() {
+		return new MetricsItemsStatusTransition(this);
+	}
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusTransition.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusTransition.java
@@ -32,11 +32,11 @@ public class MetricsItemsStatusTransition implements Serializable {
 
 	@Id
 	@Column(name = "FromStatus")
-	private int fromStatus;
+	private String fromStatus;
 
 	@Id
 	@Column(name = "ToStatus")
-	private int toStatus;
+	private String toStatus;
 
 	@Column(name = "TransitionDate")
 	private Long transitionDate;
@@ -65,19 +65,19 @@ public class MetricsItemsStatusTransition implements Serializable {
 		this.sourceSystemId = sourceSystemId;
 	}
 
-	public int getFromStatus() {
+	public String getFromStatus() {
 		return fromStatus;
 	}
 
-	public void setFromStatus(int fromStatus) {
+	public void setFromStatus(String fromStatus) {
 		this.fromStatus = fromStatus;
 	}
 
-	public int getToStatus() {
+	public String getToStatus() {
 		return toStatus;
 	}
 
-	public void setToStatus(int toStatus) {
+	public void setToStatus(String toStatus) {
 		this.toStatus = toStatus;
 	}
 
@@ -93,8 +93,8 @@ public class MetricsItemsStatusTransition implements Serializable {
 		return serialVersionUID;
 	}
 
-	public MetricsItemsStatusTransition(String itemId, String projectId, int sourceSystemId, int fromStatus,
-			int toStatus, Long transitionDate) {
+	public MetricsItemsStatusTransition(String itemId, String projectId, int sourceSystemId, String fromStatus,
+			String toStatus, Long transitionDate) {
 		super();
 		this.itemId = itemId;
 		this.projectId = projectId;
@@ -122,11 +122,11 @@ public class MetricsItemsStatusTransition implements Serializable {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + fromStatus;
+		result = prime * result + ((fromStatus == null) ? 0 : fromStatus.hashCode());
 		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
 		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
 		result = prime * result + sourceSystemId;
-		result = prime * result + toStatus;
+		result = prime * result + ((toStatus == null) ? 0 : toStatus.hashCode());
 		result = prime * result + ((transitionDate == null) ? 0 : transitionDate.hashCode());
 		return result;
 	}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusTransitionId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusTransitionId.java
@@ -15,12 +15,12 @@ public class MetricsItemsStatusTransitionId implements Serializable {
 
 	private int sourceSystemId;
 
-	private int fromStatus;
+	private String fromStatus;
 
-	private int toStatus;
+	private String toStatus;
 
-	public MetricsItemsStatusTransitionId(String itemId, String projectId, int sourceSystemId, int fromStatus,
-			int toStatus) {
+	public MetricsItemsStatusTransitionId(String itemId, String projectId, int sourceSystemId, String fromStatus,
+			String toStatus) {
 		super();
 		this.itemId = itemId;
 		this.projectId = projectId;
@@ -37,11 +37,11 @@ public class MetricsItemsStatusTransitionId implements Serializable {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + fromStatus;
+		result = prime * result + ((fromStatus == null) ? 0 : fromStatus.hashCode());
 		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
 		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
 		result = prime * result + sourceSystemId;
-		result = prime * result + toStatus;
+		result = prime * result + ((toStatus == null) ? 0 : toStatus.hashCode());
 		return result;
 	}
 
@@ -54,7 +54,10 @@ public class MetricsItemsStatusTransitionId implements Serializable {
 		if (getClass() != obj.getClass())
 			return false;
 		MetricsItemsStatusTransitionId other = (MetricsItemsStatusTransitionId) obj;
-		if (fromStatus != other.fromStatus)
+		if (fromStatus == null) {
+			if (other.fromStatus != null)
+				return false;
+		} else if (!fromStatus.equals(other.fromStatus))
 			return false;
 		if (itemId == null) {
 			if (other.itemId != null)
@@ -68,8 +71,12 @@ public class MetricsItemsStatusTransitionId implements Serializable {
 			return false;
 		if (sourceSystemId != other.sourceSystemId)
 			return false;
-		if (toStatus != other.toStatus)
+		if (toStatus == null) {
+			if (other.toStatus != null)
+				return false;
+		} else if (!toStatus.equals(other.toStatus))
 			return false;
+		
 		return true;
 	}
 

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusTransitionId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsStatusTransitionId.java
@@ -1,0 +1,77 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class MetricsItemsStatusTransitionId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String itemId;
+
+	private String projectId;
+
+	private int sourceSystemId;
+
+	private int fromStatus;
+
+	private int toStatus;
+
+	public MetricsItemsStatusTransitionId(String itemId, String projectId, int sourceSystemId, int fromStatus,
+			int toStatus) {
+		super();
+		this.itemId = itemId;
+		this.projectId = projectId;
+		this.sourceSystemId = sourceSystemId;
+		this.fromStatus = fromStatus;
+		this.toStatus = toStatus;
+	}
+
+	public MetricsItemsStatusTransitionId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + fromStatus;
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + toStatus;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsStatusTransitionId other = (MetricsItemsStatusTransitionId) obj;
+		if (fromStatus != other.fromStatus)
+			return false;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (toStatus != other.toStatus)
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsTStatusDuration.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsTStatusDuration.java
@@ -1,0 +1,179 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+@Entity(name = "metricsItemsTStatusDuration")
+@Table(name = "MetricsItemsTStatusDuration")
+@IdClass(MetricsItemsTStatusDurationId.class)
+public class MetricsItemsTStatusDuration implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "ItemId")
+	private String itemId;
+
+	@Id
+	@Column(name = "ProjectId")
+	private String projectId;
+
+	@Id
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
+
+	@Id
+	@Column(name = "Status")
+	private int status;
+
+	@Column(name = "Duration")
+	private Long duration;
+
+	public String getItemId() {
+		return itemId;
+	}
+
+	public void setItemId(String itemId) {
+		this.itemId = itemId;
+	}
+
+	public String getProjectId() {
+		return projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	public int getSourceSystemId() {
+		return sourceSystemId;
+	}
+
+	public void setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
+	}
+
+	public int getStatus() {
+		return status;
+	}
+
+	public void setStatus(int status) {
+		this.status = status;
+	}
+
+	public Long getDuration() {
+		return duration;
+	}
+
+	public void setDuration(Long duration) {
+		this.duration = duration;
+	}
+
+	public MetricsItemsTStatusDuration(String itemId, String projectId, int sourceSystemId, int status, Long duration) {
+		super();
+		this.itemId = itemId;
+		this.projectId = projectId;
+		this.sourceSystemId = sourceSystemId;
+		this.status = status;
+		this.duration = duration;
+	}
+
+	public MetricsItemsTStatusDuration() {
+		super();
+	}
+
+	public MetricsItemsTStatusDuration(MetricsItemsTStatusDuration sd) {
+		super();
+		this.itemId = sd.itemId;
+		this.projectId = sd.projectId;
+		this.sourceSystemId = sd.sourceSystemId;
+		this.status = sd.status;
+		this.duration = sd.duration;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((duration == null) ? 0 : duration.hashCode());
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + status;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsTStatusDuration other = (MetricsItemsTStatusDuration) obj;
+		if (duration == null) {
+			if (other.duration != null)
+				return false;
+		} else if (!duration.equals(other.duration))
+			return false;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (status != other.status)
+			return false;
+		return true;
+	}
+
+	   @Override
+	    public String toString() {
+	        StringBuilder builder = new StringBuilder();
+	        builder.append("MetricsItemsTStatusDuration [itemId=");
+	        builder.append(itemId);
+	        builder.append(", ProjectId=");
+	        builder.append(projectId);
+	        builder.append(", sourceSystemId=");
+	        builder.append(sourceSystemId);
+	        builder.append(", status=");
+	        builder.append(status);
+	        builder.append(", duration=");
+	        builder.append(duration);
+	        return builder.toString();
+	    }
+
+	    public String toStringWithoutDuration() {
+	        StringBuilder builder = new StringBuilder();
+	        builder.append("MetricsItemsTStatusDuration [itemId=");
+	        builder.append(itemId);
+	        builder.append(", ProjectId=");
+	        builder.append(projectId);
+	        builder.append(", sourceSystemId=");
+	        builder.append(sourceSystemId);
+	        builder.append(", status=");
+	        builder.append(status);
+	        return builder.toString();
+	    }
+
+	    public MetricsItemsTStatusDuration clone() {
+	        return new MetricsItemsTStatusDuration(this);
+	    }
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsTStatusDurationId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsTStatusDurationId.java
@@ -1,0 +1,70 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class MetricsItemsTStatusDurationId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String itemId;
+
+	private String projectId;
+
+	private int sourceSystemId;
+
+	private int status;
+
+	public MetricsItemsTStatusDurationId(String itemId, String projectId, int sourceSystemId, int status) {
+		super();
+		this.itemId = itemId;
+		this.projectId = projectId;
+		this.sourceSystemId = sourceSystemId;
+		this.status = status;
+	}
+
+	public MetricsItemsTStatusDurationId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + status;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsTStatusDurationId other = (MetricsItemsTStatusDurationId) obj;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (status != other.status)
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsTStatusTransition.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsTStatusTransition.java
@@ -1,0 +1,183 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+@Entity(name = "metricsItemsTStatusTransition")
+@Table(name = "MetricsItemsTStatusTransition")
+@IdClass(MetricsItemsTStatusTransitionId.class)
+public class MetricsItemsTStatusTransition implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "ItemId")
+	private String itemId;
+
+	@Id
+	@Column(name = "ProjectId")
+	private String projectId;
+
+	@Id
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
+
+	@Id
+	@Column(name = "Status")
+	private int status;
+
+	@Column(name = "TransitionDate")
+	private Long transitionDate;
+
+	public String getItemId() {
+		return itemId;
+	}
+
+	public void setItemId(String itemId) {
+		this.itemId = itemId;
+	}
+
+	public String getProjectId() {
+		return projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	public int getSourceSystemId() {
+		return sourceSystemId;
+	}
+
+	public void setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
+	}
+
+	public int getStatus() {
+		return status;
+	}
+
+	public void setStatus(int status) {
+		this.status = status;
+	}
+
+	public Long getTransitionDate() {
+		return transitionDate;
+	}
+
+	public void setTransitionDate(Long transitionDate) {
+		this.transitionDate = transitionDate;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
+	}
+
+	public MetricsItemsTStatusTransition(String itemId, String projectId, int sourceSystemId, int status,
+			Long transitionDate) {
+		super();
+		this.itemId = itemId;
+		this.projectId = projectId;
+		this.sourceSystemId = sourceSystemId;
+		this.status = status;
+		this.transitionDate = transitionDate;
+	}
+
+	public MetricsItemsTStatusTransition() {
+		super();
+	}
+
+	public MetricsItemsTStatusTransition(MetricsItemsTStatusTransition st) {
+		super();
+		this.itemId = st.itemId;
+		this.projectId = st.projectId;
+		this.sourceSystemId = st.sourceSystemId;
+		this.status = st.status;
+		this.transitionDate = st.transitionDate;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + status;
+		result = prime * result + ((transitionDate == null) ? 0 : transitionDate.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsTStatusTransition other = (MetricsItemsTStatusTransition) obj;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (status != other.status)
+			return false;
+		if (transitionDate == null) {
+			if (other.transitionDate != null)
+				return false;
+		} else if (!transitionDate.equals(other.transitionDate))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("MetricsItemsTStatusTransition [itemId=");
+		builder.append(itemId);
+		builder.append(", ProjectId=");
+		builder.append(projectId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", status=");
+		builder.append(status);
+		builder.append(", transitionDate=");
+		builder.append(transitionDate);
+		return builder.toString();
+	}
+
+	public String toStringWithoutDate() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("MetricsItemsTStatusTransition [itemId=");
+		builder.append(itemId);
+		builder.append(", ProjectId=");
+		builder.append(projectId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", status=");
+		builder.append(status);
+		return builder.toString();
+	}
+
+	public MetricsItemsTStatusTransition clone() {
+		return new MetricsItemsTStatusTransition(this);
+	}
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsTStatusTransitionId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/MetricsItemsTStatusTransitionId.java
@@ -1,0 +1,70 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class MetricsItemsTStatusTransitionId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String itemId;
+
+	private String projectId;
+
+	private int sourceSystemId;
+
+	private int status;
+
+	public MetricsItemsTStatusTransitionId(String itemId, String projectId, int sourceSystemId, int status) {
+		super();
+		this.itemId = itemId;
+		this.projectId = projectId;
+		this.sourceSystemId = sourceSystemId;
+		this.status = status;
+	}
+
+	public MetricsItemsTStatusTransitionId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((itemId == null) ? 0 : itemId.hashCode());
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + status;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MetricsItemsTStatusTransitionId other = (MetricsItemsTStatusTransitionId) obj;
+		if (itemId == null) {
+			if (other.itemId != null)
+				return false;
+		} else if (!itemId.equals(other.itemId))
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (status != other.status)
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Project.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Project.java
@@ -1,0 +1,295 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.util.ArrayList;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Entity(name = "project")
+@Table(name = "Project")
+@IdClass(ProjectId.class)
+public class Project {
+    
+    @Autowired
+    ChecksumUtil checksumUtil;
+
+    @Id
+    private String id;
+
+    @Id
+    private int sourceSystemId;
+
+    @Column
+    private String key;
+
+    @Column
+    private String name;
+
+    @Column
+    private long last_update_date;
+
+    private ArrayList<ProjectCustomField> projectCustomFields;
+
+    @Column
+    private String checksum;
+    
+    public Project(Project p) {
+        
+    }
+    
+    public Project(String id, int sourceSystemId, String key, String name, long last_update_date,
+            ArrayList<ProjectCustomField> projectCustomFields, String checksum) {
+        super();
+        this.id = id;
+        this.sourceSystemId = sourceSystemId;
+        this.key = key;
+        this.name = name;
+        this.last_update_date = last_update_date;
+        this.projectCustomFields = projectCustomFields;
+        this.checksum = calculateChecksum();
+    }
+    
+    public Project(String id, int sourceSystemId, String key, String name, long last_update_date,
+            ArrayList<ProjectCustomField> projectCustomFields) {
+        super();
+        this.id = id;
+        this.sourceSystemId = sourceSystemId;
+        this.key = key;
+        this.name = name;
+        this.last_update_date = last_update_date;
+        this.projectCustomFields = projectCustomFields;
+        this.checksum = calculateChecksum();
+    }
+
+    public Project() {
+        
+    }
+    
+    public final ChecksumUtil getChecksumUtil() {
+        return checksumUtil;
+    }
+
+    public final Project setChecksumUtil(ChecksumUtil checksumUtil) {
+        this.checksumUtil = checksumUtil;
+    
+        return this;
+    }
+
+    public final String getId() {
+        return id;
+    }
+
+    public final Project setId(String id) {
+        this.id = id;
+    
+        return this;
+    }
+
+    public final int getSourceSystemId() {
+        return sourceSystemId;
+    }
+
+    public final Project setSourceSystemId(int sourceSystemId) {
+        this.sourceSystemId = sourceSystemId;
+    
+        return this;
+    }
+
+    public final String getKey() {
+        return key;
+    }
+
+    public final Project setKey(String key) {
+        this.key = key;
+    
+        return this;
+    }
+
+    public final String getName() {
+        return name;
+    }
+
+    public final Project setName(String name) {
+        this.name = name;
+    
+        return this;
+    }
+
+    public final long getLast_update_date() {
+        return last_update_date;
+    }
+
+    public final Project setLast_update_date(long last_update_date) {
+        this.last_update_date = last_update_date;
+    
+        return this;
+    }
+
+    public final ArrayList<ProjectCustomField> getProjectCustomFields() {
+        return projectCustomFields;
+    }
+
+    public final Project setProjectCustomFields(ArrayList<ProjectCustomField> projectCustomFields) {
+        this.projectCustomFields = projectCustomFields;
+    
+        return this;
+    }
+
+    public final String getChecksum() {
+        return checksum;
+    }
+
+    public final Project setChecksum(String checksum) {
+        this.checksum = checksum;
+    
+        return this;
+    }
+
+    private String calculateChecksum() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.toStringWithoutCustomFieldsAndLastUpdateDate());
+
+        for (ProjectCustomField f : projectCustomFields) {
+            sb.append(f.toStringWithoutCreateDate());
+        }
+        return checksumUtil.getChecksum(sb.toString());      
+    }
+    
+    public ArrayList<ProjectCustomField> addCustomField(ProjectCustomField field) {
+
+        if (null == projectCustomFields) {
+            projectCustomFields = new ArrayList<ProjectCustomField>();
+        }
+
+        if (null != field) {
+            if (!(field.getProjectId().equals(this.getId()))) {
+                throw new RuntimeException("FieldUserId doesnot match");
+            } else {
+                Boolean fieldPresent = false;
+                for (ProjectCustomField f : projectCustomFields) {
+                    if (f.getFieldName().equals(field.getFieldName())) {
+                        fieldPresent = true;
+                        f.setFieldValue(field.getFieldValue());
+                    }
+                }
+
+                if (!fieldPresent) {
+                    projectCustomFields.add(field);
+                }
+            }
+        }
+
+        return projectCustomFields;
+    }
+
+    public String toStringWithoutCustomFieldsAndLastUpdateDate() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Project [id=");
+        builder.append(id);
+        builder.append(", sourceSystemId=");
+        builder.append(sourceSystemId);
+        builder.append(", key=");
+        builder.append(key);
+        builder.append(", name=");
+        builder.append(name);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Project [id=");
+        builder.append(id);
+        builder.append(", sourceSystemId=");
+        builder.append(sourceSystemId);
+        builder.append(", key=");
+        builder.append(key);
+        builder.append(", name=");
+        builder.append(name);
+        builder.append(", last_update_date=");
+        builder.append(last_update_date);
+        builder.append(", projectCustomFields=");
+        builder.append(projectCustomFields);
+        builder.append(", checksum=");
+        builder.append(checksum);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((checksum == null) ? 0 : checksum.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + (int) (last_update_date ^ (last_update_date >>> 32));
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((projectCustomFields == null) ? 0 : projectCustomFields.hashCode());
+        result = prime * result + sourceSystemId;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Project other = (Project) obj;
+        if (checksum == null) {
+            if (other.checksum != null) {
+                return false;
+            }
+        } else if (!checksum.equals(other.checksum)) {
+            return false;
+        }
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        if (key == null) {
+            if (other.key != null) {
+                return false;
+            }
+        } else if (!key.equals(other.key)) {
+            return false;
+        }
+        if (last_update_date != other.last_update_date) {
+            return false;
+        }
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        if (projectCustomFields == null) {
+            if (other.projectCustomFields != null) {
+                return false;
+            }
+        } else if (!projectCustomFields.equals(other.projectCustomFields)) {
+            return false;
+        }
+        if (sourceSystemId != other.sourceSystemId) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Project.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Project.java
@@ -10,13 +10,12 @@ import javax.persistence.Table;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.dtcc.workflowmetrics.exception.MetricsLogicException;
+
 @Entity(name = "project")
 @Table(name = "Project")
 @IdClass(ProjectId.class)
 public class Project {
-    
-    @Autowired
-    ChecksumUtil checksumUtil;
 
     @Id
     private String id;
@@ -37,11 +36,19 @@ public class Project {
 
     @Column
     private String checksum;
-    
-    public Project(Project p) {
-        
+
+    private Project(Project p) {
+        this.id = p.getId();
+        this.key = p.getKey();
+        this.last_update_date = p.getLast_update_date();
+        this.name = p.getName();
+        this.sourceSystemId = p.getSourceSystemId();
+        projectCustomFields = new ArrayList<ProjectCustomField>();
+        for (ProjectCustomField cf : p.getProjectCustomFields()) {
+            projectCustomFields.add(cf.clone());
+        }
     }
-    
+
     public Project(String id, int sourceSystemId, String key, String name, long last_update_date,
             ArrayList<ProjectCustomField> projectCustomFields, String checksum) {
         super();
@@ -53,7 +60,7 @@ public class Project {
         this.projectCustomFields = projectCustomFields;
         this.checksum = calculateChecksum();
     }
-    
+
     public Project(String id, int sourceSystemId, String key, String name, long last_update_date,
             ArrayList<ProjectCustomField> projectCustomFields) {
         super();
@@ -67,17 +74,7 @@ public class Project {
     }
 
     public Project() {
-        
-    }
-    
-    public final ChecksumUtil getChecksumUtil() {
-        return checksumUtil;
-    }
 
-    public final Project setChecksumUtil(ChecksumUtil checksumUtil) {
-        this.checksumUtil = checksumUtil;
-    
-        return this;
     }
 
     public final String getId() {
@@ -86,7 +83,7 @@ public class Project {
 
     public final Project setId(String id) {
         this.id = id;
-    
+
         return this;
     }
 
@@ -96,7 +93,7 @@ public class Project {
 
     public final Project setSourceSystemId(int sourceSystemId) {
         this.sourceSystemId = sourceSystemId;
-    
+
         return this;
     }
 
@@ -106,7 +103,7 @@ public class Project {
 
     public final Project setKey(String key) {
         this.key = key;
-    
+
         return this;
     }
 
@@ -116,7 +113,7 @@ public class Project {
 
     public final Project setName(String name) {
         this.name = name;
-    
+
         return this;
     }
 
@@ -126,7 +123,7 @@ public class Project {
 
     public final Project setLast_update_date(long last_update_date) {
         this.last_update_date = last_update_date;
-    
+
         return this;
     }
 
@@ -136,7 +133,7 @@ public class Project {
 
     public final Project setProjectCustomFields(ArrayList<ProjectCustomField> projectCustomFields) {
         this.projectCustomFields = projectCustomFields;
-    
+
         return this;
     }
 
@@ -146,7 +143,7 @@ public class Project {
 
     public final Project setChecksum(String checksum) {
         this.checksum = checksum;
-    
+
         return this;
     }
 
@@ -157,9 +154,9 @@ public class Project {
         for (ProjectCustomField f : projectCustomFields) {
             sb.append(f.toStringWithoutCreateDate());
         }
-        return checksumUtil.getChecksum(sb.toString());      
+        return ChecksumUtil.getChecksum(sb.toString());
     }
-    
+
     public ArrayList<ProjectCustomField> addCustomField(ProjectCustomField field) {
 
         if (null == projectCustomFields) {
@@ -168,7 +165,8 @@ public class Project {
 
         if (null != field) {
             if (!(field.getProjectId().equals(this.getId()))) {
-                throw new RuntimeException("FieldUserId doesnot match");
+                throw new MetricsLogicException("The field " + field.toString()
+                        + " does not appear to be associated with project " + this.getName());
             } else {
                 Boolean fieldPresent = false;
                 for (ProjectCustomField f : projectCustomFields) {
@@ -291,5 +289,8 @@ public class Project {
         }
         return true;
     }
-
+    
+    public Project clone() {
+        return new Project(this);
+    }
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Project.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Project.java
@@ -8,8 +8,6 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.dtcc.workflowmetrics.exception.MetricsLogicException;
 
 @Entity(name = "project")

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectCustomField.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectCustomField.java
@@ -1,0 +1,205 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+@Entity(name = "projectCustomField")
+@Table(name = "ProjectCustomField")
+@IdClass(ProjectCustomFieldId.class)
+public class ProjectCustomField implements Serializable{
+	
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "ProjectId")
+	private String projectId;
+
+	@Id
+	@Column(name = "SourceSystem")
+	private int sourceSystem;
+
+	@Id
+	@Column(name = "CreateDate")
+	private Long createDate;
+
+	@Id
+	@Column(name = "FieldName")
+	private String fieldName;
+
+	@Column(name = "FieldDatatype")
+	private String fieldDatatype;
+
+	@Column(name = "FieldValue")
+	private String fieldValue;
+
+	public String getProjectId() {
+		return projectId;
+	}
+
+	public void setProjectId(String projectId) {
+		this.projectId = projectId;
+	}
+
+	public int getSourceSystem() {
+		return sourceSystem;
+	}
+
+	public void setSourceSystem(int sourceSystem) {
+		this.sourceSystem = sourceSystem;
+	}
+
+	public Long getCreateDate() {
+		return createDate;
+	}
+
+	public void setCreateDate(Long createDate) {
+		this.createDate = createDate;
+	}
+
+	public String getFieldName() {
+		return fieldName;
+	}
+
+	public void setFieldName(String fieldName) {
+		this.fieldName = fieldName;
+	}
+
+	public String getFieldDatatype() {
+		return fieldDatatype;
+	}
+
+	public void setFieldDatatype(String fieldDatatype) {
+		this.fieldDatatype = fieldDatatype;
+	}
+
+	public String getFieldValue() {
+		return fieldValue;
+	}
+
+	public void setFieldValue(String fieldValue) {
+		this.fieldValue = fieldValue;
+	}
+
+	public ProjectCustomField(String projectId, int sourceSystem, Long createDate, String fieldName,
+			String fieldDatatype, String fieldValue) {
+		super();
+		this.projectId = projectId;
+		this.sourceSystem = sourceSystem;
+		this.createDate = createDate;
+		this.fieldName = fieldName;
+		this.fieldDatatype = fieldDatatype;
+		this.fieldValue = fieldValue;
+	}
+
+	public ProjectCustomField() {
+		super();
+	}
+
+	private ProjectCustomField(ProjectCustomField cf) {
+        this.createDate = cf.getCreateDate();
+        this.fieldDatatype = cf.getFieldDatatype();
+        this.fieldName = cf.getFieldName();
+        this.fieldValue = cf.getFieldValue();
+        this.projectId = cf.getProjectId();
+        this.sourceSystem = cf.getSourceSystem();
+    }
+
+    @Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((createDate == null) ? 0 : createDate.hashCode());
+		result = prime * result + ((fieldDatatype == null) ? 0 : fieldDatatype.hashCode());
+		result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+		result = prime * result + ((fieldValue == null) ? 0 : fieldValue.hashCode());
+		result = prime * result + sourceSystem;
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ProjectCustomField other = (ProjectCustomField) obj;
+		if (createDate == null) {
+			if (other.createDate != null)
+				return false;
+		} else if (!createDate.equals(other.createDate))
+			return false;
+		if (fieldDatatype == null) {
+			if (other.fieldDatatype != null)
+				return false;
+		} else if (!fieldDatatype.equals(other.fieldDatatype))
+			return false;
+		if (fieldName == null) {
+			if (other.fieldName != null)
+				return false;
+		} else if (!fieldName.equals(other.fieldName))
+			return false;
+		if (fieldValue == null) {
+			if (other.fieldValue != null)
+				return false;
+		} else if (!fieldValue.equals(other.fieldValue))
+			return false;
+		if (sourceSystem != other.sourceSystem)
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		return true;
+	}
+	
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ProjectCustomField [projectId=");
+        builder.append(projectId);
+        builder.append(", sourceSystem=");
+        builder.append(sourceSystem);
+        builder.append(", createDate=");
+        builder.append(createDate);
+        builder.append(", fieldName=");
+        builder.append(fieldName);
+        builder.append(", fieldDatatype=");
+        builder.append(fieldDatatype);
+        builder.append(", fieldValue=");
+        builder.append(fieldValue);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    public String toStringWithoutCreateDate() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ProjectCustomField [projectId=");
+        builder.append(projectId);
+        builder.append(", sourceSystem=");
+        builder.append(sourceSystem);
+        builder.append(", fieldName=");
+        builder.append(fieldName);
+        builder.append(", fieldDatatype=");
+        builder.append(fieldDatatype);
+        builder.append(", fieldValue=");
+        builder.append(fieldValue);
+        builder.append("]");
+        return builder.toString();
+    }
+    
+    public ProjectCustomField clone() {
+        return new ProjectCustomField(this);
+    }
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectCustomFieldId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectCustomFieldId.java
@@ -1,0 +1,75 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class ProjectCustomFieldId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String projectId;
+	
+	private int sourceSystem;
+	
+	private Long createDate;
+	
+	private String fieldName;
+
+	public ProjectCustomFieldId(String projectId, int sourceSystem, Long createDate, String fieldName) {
+		super();
+		this.projectId = projectId;
+		this.sourceSystem = sourceSystem;
+		this.createDate = createDate;
+		this.fieldName = fieldName;
+	}
+
+	
+	public ProjectCustomFieldId() {
+		super();
+	}
+
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((createDate == null) ? 0 : createDate.hashCode());
+		result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+		result = prime * result + sourceSystem;
+		result = prime * result + ((projectId == null) ? 0 : projectId.hashCode());
+		return result;
+	}
+
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ProjectCustomFieldId other = (ProjectCustomFieldId) obj;
+		if (createDate == null) {
+			if (other.createDate != null)
+				return false;
+		} else if (!createDate.equals(other.createDate))
+			return false;
+		if (fieldName == null) {
+			if (other.fieldName != null)
+				return false;
+		} else if (!fieldName.equals(other.fieldName))
+			return false;
+		if (sourceSystem != other.sourceSystem)
+			return false;
+		if (projectId == null) {
+			if (other.projectId != null)
+				return false;
+		} else if (!projectId.equals(other.projectId))
+			return false;
+		return true;
+	}
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectDetails.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectDetails.java
@@ -1,17 +1,11 @@
 package com.dtcc.workflowmetrics.entity;
 
 import java.io.Serializable;
-import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
-
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 @Entity
 @Table(name = "Project")
@@ -37,7 +31,7 @@ public class ProjectDetails implements Serializable {
 
 	@Column(name = "ProjectTypeKey")
 	private String projectTypeKey;
-
+/*
 	@JsonManagedReference
 	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
 	private List<Issue> issues;
@@ -51,7 +45,7 @@ public class ProjectDetails implements Serializable {
 
 	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
 	private List<TStatusDuration> tStatusDuration;
-
+*/
 	public Integer getProjectId() {
 		return projectId;
 	}
@@ -71,7 +65,7 @@ public class ProjectDetails implements Serializable {
 	public void setProjectName(String projectName) {
 		this.projectName = projectName;
 	}
-
+/*
 	public List<Issue> getIssues() {
 		return issues;
 	}
@@ -114,7 +108,7 @@ public class ProjectDetails implements Serializable {
 			this.tStatusDuration.addAll(tStatusDuration);
 		}
 	}
-
+*/
 	public static long getSerialversionuid() {
 		return serialVersionUID;
 	}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectDetails.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectDetails.java
@@ -8,7 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity
-@Table(name = "Project")
+@Table(name = "ProjectDetails")
 public class ProjectDetails implements Serializable {
 
 	/**

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/ProjectId.java
@@ -1,0 +1,91 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class ProjectId implements Serializable {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 231985438713995681L;
+    private String id;
+    private int sourceSystemId;
+    
+    public ProjectId() {
+        
+    }
+
+    public ProjectId(String id, int sourceSystemId) {
+        super();
+        this.id = id;
+        this.sourceSystemId = sourceSystemId;
+    }
+
+    public final String getId() {
+        return id;
+    }
+
+    public final ProjectId setId(String id) {
+        this.id = id;
+    
+        return this;
+    }
+
+    public final int getSourceSystemId() {
+        return sourceSystemId;
+    }
+
+    public final ProjectId setSourceSystemId(int sourceSystemId) {
+        this.sourceSystemId = sourceSystemId;
+    
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + sourceSystemId;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ProjectId other = (ProjectId) obj;
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        if (sourceSystemId != other.sourceSystemId) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("ProjectId [id=");
+        builder.append(id);
+        builder.append(", sourceSystemId=");
+        builder.append(sourceSystemId);
+        builder.append("]");
+        return builder.toString();
+    }
+    
+    
+    
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/SourceSystem.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/SourceSystem.java
@@ -1,0 +1,94 @@
+package com.dtcc.workflowmetrics.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity(name = "sourceSystem")
+@Table(name = "SourceSystem")
+public class SourceSystem {
+    
+    @Id
+    private Integer id;
+    
+    @Column
+    private String description;
+    
+    public SourceSystem() {
+    }
+    
+    public SourceSystem(int id, String description) {
+        this.id = Integer.valueOf(id);
+        this.description = description;
+    }
+
+    public final Integer getId() {
+        return id;
+    }
+
+    public final SourceSystem setId(Integer id) {
+        this.id = id;
+    
+        return this;
+    }
+
+    public final String getDescription() {
+        return description;
+    }
+
+    public final SourceSystem setDescription(String description) {
+        this.description = description;
+    
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        SourceSystem other = (SourceSystem) obj;
+        if (description == null) {
+            if (other.description != null) {
+                return false;
+            }
+        } else if (!description.equals(other.description)) {
+            return false;
+        }
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("SourceSystem [id=");
+        builder.append(id);
+        builder.append(", description=");
+        builder.append(description);
+        builder.append("]");
+        return builder.toString();
+    }
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Status.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Status.java
@@ -1,0 +1,367 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+@Entity(name = "status")
+@Table(name = "Status")
+@IdClass(StatusId.class)
+public class Status implements Serializable {
+
+	@Id
+	private String statusId;
+
+	@Id
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
+
+	@Column(name = "Name")
+	private String name;
+
+	@Column(name = "Description")
+	private String description;
+
+	@Column(name = "LastUpdateDate")
+	private Long lastUpdateDate;
+
+	@Column(name = "CheckSum", length = 5000)
+	private String checkSum;
+
+	private ArrayList<StatusCustomField> statusCustomField;
+
+	private ArrayList<StatusTValue> statusTValue;
+
+	public final String getStatusId() {
+		return statusId;
+	}
+
+	public final Status setStatusId(String statusId) {
+		this.statusId = statusId;
+		return this;
+	}
+
+	public final int getSourceSystemId() {
+		return sourceSystemId;
+	}
+
+	public final Status setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
+		return this;
+	}
+
+	public final String getName() {
+		return name;
+	}
+
+	public final Status setName(String name) {
+		this.name = name;
+		return this;
+	}
+
+	public final String getDescription() {
+		return description;
+	}
+
+	public final Status setDescription(String description) {
+		this.description = description;
+		return this;
+	}
+
+	public final Long getLastUpdateDate() {
+		return lastUpdateDate;
+	}
+
+	public final Status setLastUpdateDate(Long lastUpdateDate) {
+		this.lastUpdateDate = lastUpdateDate;
+		return this;
+	}
+
+	public final String getCheckSum() {
+		return checkSum;
+	}
+
+	public final Status setCheckSum(String checkSum) {
+		this.checkSum = checkSum;
+		return this;
+	}
+
+	public final ArrayList<StatusCustomField> getStatusCustomField() {
+		return statusCustomField;
+	}
+
+	public final Status setStatusCustomField(ArrayList<StatusCustomField> statusCustomField) {
+		this.statusCustomField = statusCustomField;
+		return this;
+	}
+
+	public final ArrayList<StatusTValue> getStatusTValue() {
+		return statusTValue;
+	}
+
+	public final Status setStatusTValue(ArrayList<StatusTValue> statusTValue) {
+		this.statusTValue = statusTValue;
+		return this;
+	}
+
+	public Status(String statusId, int sourceSystemId, String name, String description, Long lastUpdateDate,
+			String checkSum, ArrayList<StatusCustomField> statusCustomField, ArrayList<StatusTValue> statusTValue) {
+		super();
+		this.statusId = statusId;
+		this.sourceSystemId = sourceSystemId;
+		this.name = name;
+		this.description = description;
+		this.lastUpdateDate = lastUpdateDate;
+		this.checkSum = calculateChecksum();
+		this.statusCustomField = statusCustomField;
+		this.statusTValue = statusTValue;
+	}
+
+	public Status(String statusId, int sourceSystemId, String name, String description, Long lastUpdateDate,
+			ArrayList<StatusCustomField> statusCustomField, ArrayList<StatusTValue> statusTValue) {
+		super();
+		this.statusId = statusId;
+		this.sourceSystemId = sourceSystemId;
+		this.name = name;
+		this.description = description;
+		this.lastUpdateDate = lastUpdateDate;
+		this.checkSum = calculateChecksum();
+		this.statusCustomField = statusCustomField;
+		this.statusTValue = statusTValue;
+	}
+
+	public Status(Status s) {
+		super();
+		this.statusId = s.statusId;
+		this.sourceSystemId = s.sourceSystemId;
+		this.name = s.name;
+		this.description = s.description;
+		this.lastUpdateDate = s.lastUpdateDate;
+		this.checkSum = s.checkSum;
+		statusCustomField = new ArrayList<StatusCustomField>();
+		for (StatusCustomField cf : s.getStatusCustomField()) {
+			statusCustomField.add(cf.clone());
+		}
+		
+		statusTValue = new ArrayList<StatusTValue>();
+		for (StatusTValue tv : s.getStatusTValue()) {
+			statusTValue.add(tv.clone());
+		}
+		
+	}
+
+	public Status() {
+		super();
+	}
+
+	public ArrayList<StatusCustomField> addCustomField(StatusCustomField field) {
+
+		if (null == statusCustomField) {
+			statusCustomField = new ArrayList<StatusCustomField>();
+		}
+
+		if (null != field) {
+			if (!(field.getStatusId().equals(this.getStatusId()))) {
+				throw new RuntimeException("StatusId doesnot match");
+			} else {
+				Boolean fieldPresent = false;
+				for (StatusCustomField s : statusCustomField) {
+					if (s.getFieldName().equals(field.getFieldName())) {
+						fieldPresent = true;
+						s.setFieldValue(field.getFieldValue());
+					}
+				}
+
+				if (!fieldPresent) {
+					statusCustomField.add(field);
+				}
+			}
+		}
+
+		return statusCustomField;
+	}
+
+	public ArrayList<StatusTValue> addStatusTValue(StatusTValue value) {
+
+		if (null == statusTValue) {
+			statusTValue = new ArrayList<StatusTValue>();
+		}
+
+		if (null != value) {
+			if (!(value.getStatusId().equals(this.getStatusId()))) {
+				throw new RuntimeException("StatusId doesnot match");
+			} else {
+				Boolean fieldPresent = false;
+				for (StatusTValue s : statusTValue) {
+					if (s.getTValue() == value.getTValue()) {
+						fieldPresent = true;
+						s.setTValue(value.getTValue());
+					}
+				}
+
+				if (!fieldPresent) {
+					statusTValue.add(value);
+				}
+			}
+		}
+
+		return statusTValue;
+	}
+
+	public Status clone() {
+		Status clone = new Status();
+		clone.setStatusId(this.statusId);
+		clone.setSourceSystemId(this.sourceSystemId);
+		clone.setName(this.name);
+		clone.setDescription(this.description);
+		clone.setLastUpdateDate(this.lastUpdateDate);
+		clone.setCheckSum(this.checkSum);
+
+		ArrayList<StatusCustomField> arr = new ArrayList<StatusCustomField>();
+
+		for (StatusCustomField s : this.statusCustomField) {
+
+			arr.add(new StatusCustomField(s));
+
+		}
+
+		clone.setStatusCustomField(arr);
+
+		ArrayList<StatusTValue> val = new ArrayList<StatusTValue>();
+
+		for (StatusTValue v : this.statusTValue) {
+
+			val.add(new StatusTValue(v));
+
+		}
+
+		clone.setStatusTValue(val);
+
+		return clone;
+	}
+
+	private String calculateChecksum() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(this.toStringWithoutCustomFieldsAndLastUpdateDate());
+
+		for (StatusCustomField f : statusCustomField) {
+			sb.append(f.toStringWithoutCreateDate());
+		}
+
+		for (StatusTValue v : statusTValue) {
+			sb.append(v.toStringWithoutCreateDate());
+		}
+
+		return ChecksumUtil.getChecksum(sb.toString());
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("Status [statusId=");
+		builder.append(statusId);
+		builder.append(", SourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", name=");
+		builder.append(name);
+		builder.append(", description=");
+		builder.append(description);
+		builder.append(", lastUpdateDate=");
+		builder.append(lastUpdateDate);
+		builder.append(", statusCustomField=");
+		builder.append(statusCustomField);
+		builder.append(", statusTValue=");
+		builder.append(statusTValue);
+		builder.append(", checkSum=");
+		builder.append(checkSum);
+		builder.append("]");
+		return builder.toString();
+	}
+
+	public String toStringWithoutCustomFieldsAndLastUpdateDate() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("Status [statusId=");
+		builder.append(statusId);
+		builder.append(", SourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", name=");
+		builder.append(name);
+		builder.append(", description=");
+		builder.append(description);
+		builder.append(", checkSum=");
+		builder.append(checkSum);
+		builder.append("]");
+		return builder.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((checkSum == null) ? 0 : checkSum.hashCode());
+		result = prime * result + ((description == null) ? 0 : description.hashCode());
+		result = prime * result + ((lastUpdateDate == null) ? 0 : lastUpdateDate.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + ((statusCustomField == null) ? 0 : statusCustomField.hashCode());
+		result = prime * result + ((statusId == null) ? 0 : statusId.hashCode());
+		result = prime * result + ((statusTValue == null) ? 0 : statusTValue.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Status other = (Status) obj;
+		if (checkSum == null) {
+			if (other.checkSum != null)
+				return false;
+		} else if (!checkSum.equals(other.checkSum))
+			return false;
+		if (description == null) {
+			if (other.description != null)
+				return false;
+		} else if (!description.equals(other.description))
+			return false;
+		if (lastUpdateDate == null) {
+			if (other.lastUpdateDate != null)
+				return false;
+		} else if (!lastUpdateDate.equals(other.lastUpdateDate))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (statusCustomField == null) {
+			if (other.statusCustomField != null)
+				return false;
+		} else if (!statusCustomField.equals(other.statusCustomField))
+			return false;
+		if (statusId == null) {
+			if (other.statusId != null)
+				return false;
+		} else if (!statusId.equals(other.statusId))
+			return false;
+		if (statusTValue == null) {
+			if (other.statusTValue != null)
+				return false;
+		} else if (!statusTValue.equals(other.statusTValue))
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Status.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/Status.java
@@ -147,12 +147,12 @@ public class Status implements Serializable {
 		for (StatusCustomField cf : s.getStatusCustomField()) {
 			statusCustomField.add(cf.clone());
 		}
-		
+
 		statusTValue = new ArrayList<StatusTValue>();
 		for (StatusTValue tv : s.getStatusTValue()) {
 			statusTValue.add(tv.clone());
 		}
-		
+
 	}
 
 	public Status() {
@@ -249,14 +249,16 @@ public class Status implements Serializable {
 		StringBuilder sb = new StringBuilder();
 		sb.append(this.toStringWithoutCustomFieldsAndLastUpdateDate());
 
-		for (StatusCustomField f : statusCustomField) {
-			sb.append(f.toStringWithoutCreateDate());
+		if (statusCustomField != null) {
+			for (StatusCustomField f : statusCustomField) {
+				sb.append(f.toStringWithoutCreateDate());
+			}
 		}
-
-		for (StatusTValue v : statusTValue) {
-			sb.append(v.toStringWithoutCreateDate());
+		if (statusTValue != null) {
+			for (StatusTValue v : statusTValue) {
+				sb.append(v.toStringWithoutCreateDate());
+			}
 		}
-
 		return ChecksumUtil.getChecksum(sb.toString());
 	}
 
@@ -363,5 +365,4 @@ public class Status implements Serializable {
 		return true;
 	}
 
-	
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusCustomField.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusCustomField.java
@@ -8,10 +8,10 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
 
-@Entity(name = "eventUserCustomField")
-@Table(name = "EventUserCustomField")
-@IdClass(EventUserCustomFieldId.class)
-public class EventUserCustomField implements Serializable {
+@Entity(name = "statusCustomField")
+@Table(name = "StatusCustomField")
+@IdClass(StatusCustomFieldId.class)
+public class StatusCustomField implements Serializable {
 
 	/**
 	 * 
@@ -19,12 +19,12 @@ public class EventUserCustomField implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	@Id
-	@Column(name = "UserID")
-	private String userID;
+	@Column(name = "StatusId")
+	private String statusId;
 
 	@Id
-	@Column(name = "SourceSystem")
-	private int sourceSystem;
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
 
 	@Id
 	@Column(name = "CreateDate")
@@ -40,20 +40,20 @@ public class EventUserCustomField implements Serializable {
 	@Column(name = "FieldValue")
 	private String fieldValue;
 
-	public String getUserID() {
-		return userID;
+	public String getStatusId() {
+		return statusId;
 	}
 
-	public void setUserID(String userID) {
-		this.userID = userID;
+	public void setStatusId(String statusId) {
+		this.statusId = statusId;
 	}
 
-	public int getSourceSystem() {
-		return sourceSystem;
+	public int getSourceSystemId() {
+		return sourceSystemId;
 	}
 
-	public void setSourceSystem(int sourceSystem) {
-		this.sourceSystem = sourceSystem;
+	public void setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
 	}
 
 	public Long getCreateDate() {
@@ -88,28 +88,29 @@ public class EventUserCustomField implements Serializable {
 		this.fieldValue = fieldValue;
 	}
 
-	public EventUserCustomField(String userID, int sourceSystem, Long createDate, String fieldName,
+	public StatusCustomField(String statusId, int sourceSystemId, Long createDate, String fieldName,
 			String fieldDatatype, String fieldValue) {
 		super();
-		this.userID = userID;
-		this.sourceSystem = sourceSystem;
+		this.statusId = statusId;
+		this.sourceSystemId = sourceSystemId;
 		this.createDate = createDate;
 		this.fieldName = fieldName;
 		this.fieldDatatype = fieldDatatype;
 		this.fieldValue = fieldValue;
 	}
 
-	public EventUserCustomField() {
+	public StatusCustomField() {
 		super();
 	}
 
-	public EventUserCustomField(EventUserCustomField e) {
-		this.userID = e.userID;
-		this.sourceSystem = e.sourceSystem;
-		this.createDate = e.createDate;
-		this.fieldName = e.fieldName;
-		this.fieldDatatype = e.fieldDatatype;
-		this.fieldValue = e.fieldValue;
+	public StatusCustomField(StatusCustomField s) {
+		super();
+		this.statusId = s.statusId;
+		this.sourceSystemId = s.sourceSystemId;
+		this.createDate = s.createDate;
+		this.fieldName = s.fieldName;
+		this.fieldDatatype = s.fieldDatatype;
+		this.fieldValue = s.fieldValue;
 	}
 
 	@Override
@@ -120,8 +121,8 @@ public class EventUserCustomField implements Serializable {
 		result = prime * result + ((fieldDatatype == null) ? 0 : fieldDatatype.hashCode());
 		result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
 		result = prime * result + ((fieldValue == null) ? 0 : fieldValue.hashCode());
-		result = prime * result + sourceSystem;
-		result = prime * result + ((userID == null) ? 0 : userID.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + ((statusId == null) ? 0 : statusId.hashCode());
 		return result;
 	}
 
@@ -133,7 +134,7 @@ public class EventUserCustomField implements Serializable {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		EventUserCustomField other = (EventUserCustomField) obj;
+		StatusCustomField other = (StatusCustomField) obj;
 		if (createDate == null) {
 			if (other.createDate != null)
 				return false;
@@ -154,35 +155,53 @@ public class EventUserCustomField implements Serializable {
 				return false;
 		} else if (!fieldValue.equals(other.fieldValue))
 			return false;
-		if (sourceSystem != other.sourceSystem)
+		if (sourceSystemId != other.sourceSystemId)
 			return false;
-		if (userID == null) {
-			if (other.userID != null)
+		if (statusId == null) {
+			if (other.statusId != null)
 				return false;
-		} else if (!userID.equals(other.userID))
+		} else if (!statusId.equals(other.statusId))
 			return false;
 		return true;
 	}
 
-    public EventUserCustomField clone() {
-        return new EventUserCustomField(this);
-    }
-    
-    public String toStringWithoutCreateDate() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("EventUserCustomField [userID=");
-        builder.append(userID);
-        builder.append(", sourceSystem=");
-        builder.append(sourceSystem);
-        builder.append(", fieldName=");
-        builder.append(fieldName);
-        builder.append(", fieldDatatype=");
-        builder.append(fieldDatatype);
-        builder.append(", fieldValue=");
-        builder.append(fieldValue);
-        builder.append("]");
-        return builder.toString();
-    }
-  
+	public StatusCustomField clone() {
+		return new StatusCustomField(this);
+	}
+
+	public String toStringWithoutCreateDate() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("StatusCustomField [StatusId=");
+		builder.append(statusId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", fieldName=");
+		builder.append(fieldName);
+		builder.append(", fieldDatatype=");
+		builder.append(fieldDatatype);
+		builder.append(", fieldValue=");
+		builder.append(fieldValue);
+		builder.append("]");
+		return builder.toString();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("StatusCustomField [StatusId=");
+		builder.append(statusId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", createDate=");
+		builder.append(createDate);
+		builder.append(", fieldName=");
+		builder.append(fieldName);
+		builder.append(", fieldDatatype=");
+		builder.append(fieldDatatype);
+		builder.append(", fieldValue=");
+		builder.append(fieldValue);
+		builder.append("]");
+		return builder.toString();
+	}
 
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusCustomFieldId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusCustomFieldId.java
@@ -1,0 +1,73 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class StatusCustomFieldId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String statusId;
+
+	private int sourceSystemId;
+
+	private Long createDate;
+
+	private String fieldName;
+
+	public StatusCustomFieldId(String statusID, int sourceSystemId, Long createDate, String fieldName) {
+		super();
+		this.statusId = statusID;
+		this.sourceSystemId = sourceSystemId;
+		this.createDate = createDate;
+		this.fieldName = fieldName;
+	}
+
+	public StatusCustomFieldId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((createDate == null) ? 0 : createDate.hashCode());
+		result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + ((statusId == null) ? 0 : statusId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		StatusCustomFieldId other = (StatusCustomFieldId) obj;
+		if (createDate == null) {
+			if (other.createDate != null)
+				return false;
+		} else if (!createDate.equals(other.createDate))
+			return false;
+		if (fieldName == null) {
+			if (other.fieldName != null)
+				return false;
+		} else if (!fieldName.equals(other.fieldName))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (statusId == null) {
+			if (other.statusId != null)
+				return false;
+		} else if (!statusId.equals(other.statusId))
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusId.java
@@ -1,0 +1,55 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class StatusId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String statusId;
+
+	private int sourceSystemId;
+
+	public StatusId(String statusId, int sourceSystemId) {
+		super();
+		this.statusId = statusId;
+		this.sourceSystemId = sourceSystemId;
+	}
+
+	public StatusId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + sourceSystemId;
+		result = prime * result + ((statusId == null) ? 0 : statusId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		StatusId other = (StatusId) obj;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (statusId == null) {
+			if (other.statusId != null)
+				return false;
+		} else if (!statusId.equals(other.statusId))
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusTValue.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusTValue.java
@@ -1,0 +1,156 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+@Entity(name = "statusTValue")
+@Table(name = "StatusTValue")
+@IdClass(StatusTValueId.class)
+public class StatusTValue implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@Column(name = "StatusID")
+	private String statusId;
+
+	@Id
+	@Column(name = "SourceSystemId")
+	private int sourceSystemId;
+
+	@Column(name = "CreateDate")
+	private Long createDate;
+
+	@Id
+	@Column(name = "TValue")
+	private int tValue;
+
+	public String getStatusId() {
+		return statusId;
+	}
+
+	public void setStatusId(String statusId) {
+		this.statusId = statusId;
+	}
+
+	public int getSourceSystemId() {
+		return sourceSystemId;
+	}
+
+	public void setSourceSystemId(int sourceSystemId) {
+		this.sourceSystemId = sourceSystemId;
+	}
+
+	public Long getCreateDate() {
+		return createDate;
+	}
+
+	public void setCreateDate(Long createDate) {
+		this.createDate = createDate;
+	}
+
+	public int getTValue() {
+		return tValue;
+	}
+
+	public void setTValue(int tValue) {
+		this.tValue = tValue;
+	}
+
+	public StatusTValue(String statusId, int sourceSystemId, Long createDate, int tValue) {
+		super();
+		this.statusId = statusId;
+		this.sourceSystemId = sourceSystemId;
+		this.createDate = createDate;
+		this.tValue = tValue;
+	}
+
+	public StatusTValue(StatusTValue s) {
+		super();
+		this.statusId = s.statusId;
+		this.sourceSystemId = s.sourceSystemId;
+		this.createDate = s.createDate;
+		this.tValue = s.tValue;
+	}
+
+	public StatusTValue() {
+		super();
+	}
+
+	public StatusTValue clone() {
+		return new StatusTValue(this);
+	}
+
+	public String toStringWithoutCreateDate() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("StatusTValue [statusId=");
+		builder.append(statusId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", tValue=");
+		builder.append(tValue);
+		builder.append("]");
+		return builder.toString();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("StatusTValue [statusId=");
+		builder.append(statusId);
+		builder.append(", sourceSystemId=");
+		builder.append(sourceSystemId);
+		builder.append(", createDate=");
+		builder.append(createDate);
+		builder.append(", tValue=");
+		builder.append(tValue);
+		builder.append("]");
+		return builder.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + tValue;
+		result = prime * result + ((createDate == null) ? 0 : createDate.hashCode());
+		result = prime * result + sourceSystemId;
+		result = prime * result + ((statusId == null) ? 0 : statusId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		StatusTValue other = (StatusTValue) obj;
+		if (tValue != other.tValue)
+			return false;
+		if (createDate == null) {
+			if (other.createDate != null)
+				return false;
+		} else if (!createDate.equals(other.createDate))
+			return false;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (statusId == null) {
+			if (other.statusId != null)
+				return false;
+		} else if (!statusId.equals(other.statusId))
+			return false;
+		return true;
+	}
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusTValueId.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/StatusTValueId.java
@@ -1,0 +1,55 @@
+package com.dtcc.workflowmetrics.entity;
+
+import java.io.Serializable;
+
+public class StatusTValueId implements Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private String statusId;
+
+	private int sourceSystemId;
+
+	public StatusTValueId(String statusId, int sourceSystemId) {
+		super();
+		this.statusId = statusId;
+		this.sourceSystemId = sourceSystemId;
+	}
+
+	public StatusTValueId() {
+		super();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + sourceSystemId;
+		result = prime * result + ((statusId == null) ? 0 : statusId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		StatusTValueId other = (StatusTValueId) obj;
+		if (sourceSystemId != other.sourceSystemId)
+			return false;
+		if (statusId == null) {
+			if (other.statusId != null)
+				return false;
+		} else if (!statusId.equals(other.statusId))
+			return false;
+		return true;
+	}
+
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/TStatusDuration.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/entity/TStatusDuration.java
@@ -56,6 +56,31 @@ public class TStatusDuration implements Serializable {
 	@Column(name = "TStatus")
 	private String TStatus;
 
+	
+	public Issue getIssue() {
+		return issue;
+	}
+
+	public void setIssue(Issue issue) {
+		this.issue = issue;
+	}
+
+	public ProjectDetails getProjectDetail() {
+		return projectDetail;
+	}
+
+	public void setProjectDetail(ProjectDetails projectDetail) {
+		this.projectDetail = projectDetail;
+	}
+
+	public static long getSerialversionuid() {
+		return serialVersionUID;
+	}
+
+	public void setProjectID(int projectID) {
+		this.projectID = projectID;
+	}
+
 	public Integer gettStatusDurationId() {
 		return tStatusDurationId;
 	}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/ErrorConstants.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/ErrorConstants.java
@@ -1,0 +1,8 @@
+package com.dtcc.workflowmetrics.exception;
+
+public class ErrorConstants {
+    public static final String ERROR_MESSAGE="Error Message";
+    public static final String ERROR_CODE="Error Code";
+    
+    public static final Integer GENERAL_SYSTEM_EXCEPTION = new Integer(9999);
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/ExceptionUtil.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/ExceptionUtil.java
@@ -1,0 +1,19 @@
+package com.dtcc.workflowmetrics.exception;
+
+public final class ExceptionUtil {
+
+    public ExceptionUtil() {
+       
+    }
+    
+    public static final String lookupMessage(Integer errorCode) {
+        //TODO:  Implement this
+        return "This is an error message";
+    }
+    
+    public static final Integer lookupErrorCode(String errorMessage) {
+        //TODO:  Implement this
+        return new Integer(9999);
+    }
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/MetricsError.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/MetricsError.java
@@ -1,0 +1,81 @@
+package com.dtcc.workflowmetrics.exception;
+
+public class MetricsError {
+    private Integer errorCode;
+    private String errorMessage;
+    
+    public MetricsError(Integer errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public final Integer getErrorCode() {
+        return errorCode;
+    }
+
+    public final MetricsError setErrorCode(Integer errorCode) {
+        this.errorCode = errorCode;
+    
+        return this;
+    }
+
+    public final String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public final MetricsError setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((errorCode == null) ? 0 : errorCode.hashCode());
+        result = prime * result + ((errorMessage == null) ? 0 : errorMessage.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        MetricsError other = (MetricsError) obj;
+        if (errorCode == null) {
+            if (other.errorCode != null) {
+                return false;
+            }
+        } else if (!errorCode.equals(other.errorCode)) {
+            return false;
+        }
+        if (errorMessage == null) {
+            if (other.errorMessage != null) {
+                return false;
+            }
+        } else if (!errorMessage.equals(other.errorMessage)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("MetricsError [errorCode=");
+        builder.append(errorCode);
+        builder.append(", errorMessage=");
+        builder.append(errorMessage);
+        builder.append("]");
+        return builder.toString();
+    }
+    
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/MetricsException.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/MetricsException.java
@@ -1,0 +1,92 @@
+package com.dtcc.workflowmetrics.exception;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.UUID;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+public abstract class MetricsException extends RuntimeException {
+
+    private UUID uuid;
+    private Integer errorCode;
+    private String errorMessage;
+
+    private HashMap<String, Object> exceptionData;
+
+    public MetricsException() {
+        super();
+        uuid = UUID.fromString(ErrorConstants.GENERAL_SYSTEM_EXCEPTION.toString() + "-"
+                + ExceptionUtil.lookupMessage(ErrorConstants.GENERAL_SYSTEM_EXCEPTION));
+    }
+
+    public MetricsException(String message) {
+        super(message);
+        uuid = UUID.fromString(ExceptionUtil.lookupErrorCode(message) + "-" + message);
+        addInfo(ErrorConstants.ERROR_MESSAGE, message);
+        addInfo(ErrorConstants.ERROR_CODE, ExceptionUtil.lookupErrorCode(message));
+    }
+
+    public MetricsException(Throwable cause) {
+        super(cause);
+        uuid = UUID.fromString(ExceptionUtil.lookupErrorCode(this.getMessage()) + "-" + this.getMessage());
+        addInfo(ErrorConstants.ERROR_MESSAGE, this.getMessage());
+        addInfo(ErrorConstants.ERROR_CODE, ExceptionUtil.lookupErrorCode(this.getMessage()));
+    }
+
+    public MetricsException(String message, Throwable cause) {
+        super(message, cause);
+        uuid = UUID.fromString(ExceptionUtil.lookupErrorCode(this.getMessage()) + "-" + this.getMessage());
+        addInfo(ErrorConstants.ERROR_MESSAGE, this.getMessage());
+        addInfo(ErrorConstants.ERROR_CODE, ExceptionUtil.lookupErrorCode(this.getMessage()));
+    }
+
+    public MetricsException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        uuid = UUID.fromString(ExceptionUtil.lookupErrorCode(this.getMessage()) + "-" + this.getMessage());
+        addInfo(ErrorConstants.ERROR_MESSAGE, this.getMessage());
+        addInfo(ErrorConstants.ERROR_CODE, ExceptionUtil.lookupErrorCode(this.getMessage()));
+    }
+
+    public MetricsException(Integer errorCode) {
+        super(ExceptionUtil.lookupMessage(errorCode));
+        uuid = UUID.fromString(errorCode.toString() + "-" + ExceptionUtil.lookupMessage(errorCode));
+        addInfo(ErrorConstants.ERROR_MESSAGE, ExceptionUtil.lookupMessage(errorCode));
+        addInfo(ErrorConstants.ERROR_CODE, errorCode);
+    }
+    
+    public MetricsException(Integer errorCode, Throwable cause) {
+        super(ExceptionUtil.lookupMessage(errorCode), cause);
+        uuid = UUID.fromString(errorCode.toString() + "-" + ExceptionUtil.lookupMessage(errorCode));
+        addInfo(ErrorConstants.ERROR_MESSAGE, ExceptionUtil.lookupMessage(errorCode));
+        addInfo(ErrorConstants.ERROR_CODE, errorCode);
+    }
+
+    public MetricsException addInfo(String key, Object value) {
+        if (null == exceptionData) {
+            exceptionData = new HashMap<String, Object>();
+        }
+
+        exceptionData.put(key, value);
+        return this;
+    }
+
+    public String getMetricsKeyValuePairsAsJSON() {
+        if (null == exceptionData || exceptionData.isEmpty()) {
+            return null;
+        }
+        
+        ObjectMapper mapper = (new ObjectMapper()).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        
+        try {
+            return mapper.writeValueAsString(exceptionData);
+        } catch (JsonProcessingException e) {
+            return "Unable to process exception data";
+        }
+    }
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/MetricsLogicException.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/MetricsLogicException.java
@@ -6,6 +6,35 @@ public class MetricsLogicException extends MetricsException {
     
     private ArrayList<MetricsError> errors = new ArrayList<MetricsError>();
 
+    public MetricsLogicException() {
+        super();
+    }
+
+    public MetricsLogicException(Integer errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+    public MetricsLogicException(Integer errorCode) {
+        super(errorCode);
+    }
+
+    public MetricsLogicException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public MetricsLogicException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MetricsLogicException(String message) {
+        super(message);
+    }
+
+    public MetricsLogicException(Throwable cause) {
+        super(cause);
+    }
+
     public final ArrayList<MetricsError> getErrors() {
         return errors;
     }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/MetricsLogicException.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/exception/MetricsLogicException.java
@@ -1,0 +1,18 @@
+package com.dtcc.workflowmetrics.exception;
+
+import java.util.ArrayList;
+
+public class MetricsLogicException extends MetricsException {
+    
+    private ArrayList<MetricsError> errors = new ArrayList<MetricsError>();
+
+    public final ArrayList<MetricsError> getErrors() {
+        return errors;
+    }
+
+    public final MetricsLogicException setErrors(ArrayList<MetricsError> errors) {
+        this.errors = errors;
+    
+        return this;
+    }
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/metricsitems/jira/issue/Issue.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/metricsitems/jira/issue/Issue.java
@@ -1,7 +1,5 @@
 package com.dtcc.workflowmetrics.metricsitems.jira.issue;
 
-import java.util.ArrayList;
-
 public class Issue {
     private String expand;
     private String id;

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/EventUserDaoService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/EventUserDaoService.java
@@ -14,28 +14,34 @@ public class EventUserDaoService {
 
 	@Autowired
 	EventUserDao userDao;
-	
+
 	@Autowired
 	EventUserCustomFieldDao customFieldDao;
-	
+
 	@Transactional
-	public EventUser save(final EventUser user) {
-		
-		EventUser storedUserDetail = userDao.save(user);
-		
-		Iterable<EventUserCustomField> storedFields = customFieldDao.saveAll(user.getEventUserCustomField());
-		
-		for(EventUserCustomField sField:storedFields) {
-			storedUserDetail.addCustomField(sField);
-			
+	public EventUser save(EventUser user) {
+
+		EventUser storedUserDetail = user;
+
+		boolean checkData = userDao.existsEventUserByCheckSum(user.getCheckSum());
+
+		if (!checkData) {
+			EventUser userCopy = user.clone();
+
+			userCopy.setLastUpdateDate(System.currentTimeMillis());
+
+			storedUserDetail = userDao.save(userCopy);
+
+			for (EventUserCustomField sField : userCopy.getEventUserCustomField()) {
+				sField.setCreateDate(userCopy.getLastUpdateDate());
+			}
+
+			Iterable<EventUserCustomField> storedFields = customFieldDao.saveAll(userCopy.getEventUserCustomField());
+
 		}
 		
 		return storedUserDetail;
-		
-		
+
 	}
-	
-	
-	
-	
+
 }

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/EventUserDaoService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/EventUserDaoService.java
@@ -1,0 +1,41 @@
+package com.dtcc.workflowmetrics.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dtcc.workflowmetrics.dao.EventUserCustomFieldDao;
+import com.dtcc.workflowmetrics.dao.EventUserDao;
+import com.dtcc.workflowmetrics.entity.EventUser;
+import com.dtcc.workflowmetrics.entity.EventUserCustomField;
+
+@Service
+public class EventUserDaoService {
+
+	@Autowired
+	EventUserDao userDao;
+	
+	@Autowired
+	EventUserCustomFieldDao customFieldDao;
+	
+	@Transactional
+	public EventUser save(final EventUser user) {
+		
+		EventUser storedUserDetail = userDao.save(user);
+		
+		Iterable<EventUserCustomField> storedFields = customFieldDao.saveAll(user.getEventUserCustomField());
+		
+		for(EventUserCustomField sField:storedFields) {
+			storedUserDetail.addCustomField(sField);
+			
+		}
+		
+		return storedUserDetail;
+		
+		
+	}
+	
+	
+	
+	
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/JiraServiceImpl.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/JiraServiceImpl.java
@@ -15,7 +15,7 @@ import com.dtcc.workflowmetrics.dao.FieldsDao;
 import com.dtcc.workflowmetrics.dao.IssueDao;
 import com.dtcc.workflowmetrics.dao.IssueLinkDao;
 import com.dtcc.workflowmetrics.dao.IssueTypeDao;
-import com.dtcc.workflowmetrics.dao.ProjectDao;
+import com.dtcc.workflowmetrics.dao.ProjectDetailsDao;
 import com.dtcc.workflowmetrics.dao.TStatusDurationDao;
 import com.dtcc.workflowmetrics.dao.TransitionDao;
 import com.dtcc.workflowmetrics.dao.TransitionDurationDao;
@@ -58,7 +58,7 @@ public class JiraServiceImpl implements JiraService {
 	IssueTypeDao issueTypeDao;
 
 	@Autowired
-	ProjectDao projectDao;
+	ProjectDetailsDao projectDao;
 
 	@Autowired
 	TransitionDao transitionDao;

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/MetricsItemsDaoService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/MetricsItemsDaoService.java
@@ -1,0 +1,236 @@
+package com.dtcc.workflowmetrics.service;
+
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dtcc.workflowmetrics.dao.MetricsItemsCustomFieldDao;
+import com.dtcc.workflowmetrics.dao.MetricsItemsDao;
+import com.dtcc.workflowmetrics.dao.MetricsItemsStatusDurationDao;
+import com.dtcc.workflowmetrics.dao.MetricsItemsStatusTransitionDao;
+import com.dtcc.workflowmetrics.dao.MetricsItemsTStatusDurationDao;
+import com.dtcc.workflowmetrics.dao.MetricsItemsTStatusTransitionDao;
+import com.dtcc.workflowmetrics.dao.StatusDao;
+import com.dtcc.workflowmetrics.dao.StatusTValueDao;
+import com.dtcc.workflowmetrics.entity.MetricsItems;
+import com.dtcc.workflowmetrics.entity.MetricsItemsCustomField;
+import com.dtcc.workflowmetrics.entity.MetricsItemsStatusDuration;
+import com.dtcc.workflowmetrics.entity.MetricsItemsStatusTransition;
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusDuration;
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusTransition;
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusTransitionId;
+import com.dtcc.workflowmetrics.entity.StatusTValue;
+import com.dtcc.workflowmetrics.entity.StatusTValueId;
+
+@Service
+public class MetricsItemsDaoService {
+
+	@Autowired
+	MetricsItemsDao metricsItemsDao;
+
+	@Autowired
+	MetricsItemsCustomFieldDao metricsItemsCustomFieldDao;
+
+	@Autowired
+	MetricsItemsStatusDurationDao metricsItemsStatusDurationDao;
+
+	@Autowired
+	MetricsItemsStatusTransitionDao metricsItemsStatusTransitionDao;
+
+	@Autowired
+	MetricsItemsTStatusDurationDao metricsItemsTStatusDurationDao;
+
+	@Autowired
+	MetricsItemsTStatusTransitionDao metricsItemsTStatusTransitionDao;
+
+	@Autowired
+	StatusDao statusDao;
+
+	@Autowired
+	StatusTValueDao statusTValueDao;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Transactional
+	public MetricsItems save(MetricsItems item) {
+
+		MetricsItems storedItemDetail = item;
+
+		//check if data already exists in Metrics Items table
+		boolean checkData = metricsItemsDao.existsMetricsItemsByCheckSum(item.getCheckSum());
+
+		//if data is not present, add data
+		if (!checkData) {
+			MetricsItems itemCopy = item.clone();
+
+			Long createDt = System.currentTimeMillis();
+
+			itemCopy.setItemCreateDate(createDt);
+
+			itemCopy.setLastUpdateDate(createDt);
+
+			storedItemDetail = metricsItemsDao.save(itemCopy);
+
+			// MetricsItemsCustomField
+			for (MetricsItemsCustomField cField : itemCopy.getMetricsItemsCustomField()) {
+				cField.setCreateDate(itemCopy.getLastUpdateDate());
+			}
+
+			Iterable<MetricsItemsCustomField> storedFields = metricsItemsCustomFieldDao
+					.saveAll(itemCopy.getMetricsItemsCustomField());
+			
+
+			// MetricsItemsStatusTransition table population
+			//check if data is present in table
+			String statusQuery = "FROM MetricsItemsStatusTransition st ORDER BY st.TransitionDate DESC where ;";
+			Query query = entityManager.createQuery(statusQuery);
+			query.setMaxResults(1);
+			MetricsItemsStatusTransition result = (MetricsItemsStatusTransition) query.getResultList().get(1);
+
+			String fromStatus = null;
+			String toStatus = null;
+
+			MetricsItemsStatusTransition mist = new MetricsItemsStatusTransition();
+
+			for (MetricsItemsStatusTransition sTrans : itemCopy.getMetricsItemsStatusTransition()) {
+				fromStatus = sTrans.getFromStatus();
+				toStatus = sTrans.getToStatus();
+
+				if (result != null) {
+					mist.setItemId(result.getItemId());
+					mist.setProjectId(result.getProjectId());
+					mist.setSourceSystemId(result.getSourceSystemId());
+					mist.setFromStatus(sTrans.getFromStatus());
+					mist.setToStatus(sTrans.getToStatus());
+					mist.setTransitionDate(createDt);
+
+				} else {
+					mist.setItemId(itemCopy.getItemId());
+					mist.setProjectId(itemCopy.getProjectId());
+					mist.setSourceSystemId(itemCopy.getSourceSystemId());
+					mist.setFromStatus(sTrans.getFromStatus());
+					mist.setTransitionDate(createDt);
+					mist.setToStatus(sTrans.getToStatus());
+
+				}
+				
+				MetricsItemsStatusTransition storedStatusTrans = metricsItemsStatusTransitionDao.save(mist);
+				storedItemDetail.addStatusTransition(storedStatusTrans);
+
+			}
+
+			// MetricsItemsStatusDuration table population
+
+			MetricsItemsStatusTransition statusDetail = null;
+
+			//find if data is present in table for from status
+			Optional<MetricsItemsStatusTransition> data = metricsItemsStatusTransitionDao
+					.findByItemIdAndProjectIdAndSourceSystemIdAndToStatus(itemCopy.getItemId(), itemCopy.getProjectId(),
+							itemCopy.getSourceSystemId(), fromStatus);
+
+			if (data != null && data.isPresent()) {
+
+				statusDetail = data.get();
+			}
+
+			Long dur = createDt - statusDetail.getTransitionDate();
+
+			MetricsItemsStatusDuration misd = new MetricsItemsStatusDuration();
+
+			misd.setItemId(itemCopy.getItemId());
+			misd.setProjectId(itemCopy.getProjectId());
+			misd.setSourceSystemId(itemCopy.getSourceSystemId());
+			misd.setStatus(fromStatus);
+			misd.setDuration(dur);
+
+			MetricsItemsStatusDuration storedSDuration = metricsItemsStatusDurationDao.save(misd);
+			storedItemDetail.addStatusDuration(storedSDuration);
+
+			// MetricsItemsTStatusTransition data population
+			// get tvalue to for the from and to status values
+			StatusTValueId toStatusTValueId = new StatusTValueId(toStatus, itemCopy.getSourceSystemId());
+			Optional<StatusTValue> toStatusTValue = statusTValueDao.findById(toStatusTValueId);
+
+			StatusTValueId fromStatusTValueId = new StatusTValueId(fromStatus, itemCopy.getSourceSystemId());
+			Optional<StatusTValue> fromStatusTValue = statusTValueDao.findById(fromStatusTValueId);
+
+			StatusTValue toStatustValueDetail = null;
+			StatusTValue fromStatustValueDetail = null;
+
+			if (toStatusTValue != null && toStatusTValue.isPresent()) {
+
+				toStatustValueDetail = toStatusTValue.get();
+			}
+
+			if (fromStatusTValue != null && fromStatusTValue.isPresent()) {
+
+				fromStatustValueDetail = fromStatusTValue.get();
+			}
+
+			//find if data already exists in table
+			MetricsItemsTStatusTransitionId toStatustStatusTransId = new MetricsItemsTStatusTransitionId(
+					itemCopy.getItemId(), itemCopy.getProjectId(), itemCopy.getSourceSystemId(),
+					toStatustValueDetail.getTValue());
+			Optional<MetricsItemsTStatusTransition> tStatusTransDetail = metricsItemsTStatusTransitionDao
+					.findById(toStatustStatusTransId);
+
+			//if data not present, insert data, else ignore
+			if (tStatusTransDetail == null || !(tStatusTransDetail.isPresent())) {
+
+				MetricsItemsTStatusTransition mitst = new MetricsItemsTStatusTransition();
+
+				mitst.setItemId(itemCopy.getItemId());
+				mitst.setProjectId(itemCopy.getProjectId());
+				mitst.setSourceSystemId(itemCopy.getSourceSystemId());
+				mitst.setStatus(toStatustValueDetail.getTValue());
+				mitst.setTransitionDate(createDt);
+
+				MetricsItemsTStatusTransition storedTTrans = metricsItemsTStatusTransitionDao.save(mitst);
+				storedItemDetail.addTStatusTransition(storedTTrans);
+
+				// MetricsItemsTStatusDuration data population
+
+				if (toStatustValueDetail.getTValue() != fromStatustValueDetail.getTValue()) {
+
+					//find if data for previous status exists
+					MetricsItemsTStatusTransitionId fromStatustStatusTransId = new MetricsItemsTStatusTransitionId(
+							itemCopy.getItemId(), itemCopy.getProjectId(), itemCopy.getSourceSystemId(),
+							fromStatustValueDetail.getTValue());
+					Optional<MetricsItemsTStatusTransition> prevTStatusTransDetail = metricsItemsTStatusTransitionDao
+							.findById(fromStatustStatusTransId);
+
+					//if data for previous status exists, find duration, else ignore
+					if (prevTStatusTransDetail != null && prevTStatusTransDetail.isPresent()) {
+
+						Long tStatusDur = createDt - prevTStatusTransDetail.get().getTransitionDate();
+
+						MetricsItemsTStatusDuration mitsd = new MetricsItemsTStatusDuration();
+
+						mitsd.setItemId(itemCopy.getItemId());
+						mitsd.setProjectId(itemCopy.getProjectId());
+						mitsd.setSourceSystemId(itemCopy.getSourceSystemId());
+						mitsd.setStatus(fromStatustValueDetail.getTValue());
+						mitsd.setDuration(tStatusDur);
+
+						MetricsItemsTStatusDuration storedTSDuration = metricsItemsTStatusDurationDao.save(mitsd);
+						storedItemDetail.addTStatusDuration(storedTSDuration);
+						
+					}
+
+				}
+
+			}
+
+		}
+
+		return storedItemDetail;
+	}
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/MetricsItemsDaoService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/MetricsItemsDaoService.java
@@ -101,7 +101,7 @@ public class MetricsItemsDaoService {
 				toStatus = sTrans.getToStatus();
 
 				if (resultDetails.size() > 0) {
-					MetricsItemsStatusTransition result = resultDetails.get(1);
+					MetricsItemsStatusTransition result = resultDetails.get(0);
 
 					StatusId si1 = new StatusId(fromStatus, result.getSourceSystemId());
 					Optional<Status> st1 = statusDao.findById(si1);
@@ -149,7 +149,7 @@ public class MetricsItemsDaoService {
 								+ ", hence no data in MetricsItemsTStatusTransition table and MetricsItemsTStatusDuration. Please insert data to see detailed data");
 					}
 
-					StatusId si2 = new StatusId(fromStatus, itemCopy.getSourceSystemId());
+					StatusId si2 = new StatusId(toStatus, itemCopy.getSourceSystemId());
 					Optional<Status> st2 = statusDao.findById(si2);
 
 					if (st2 == null || st2.isPresent() == false) {
@@ -253,7 +253,7 @@ public class MetricsItemsDaoService {
 				mitst.setItemId(itemCopy.getItemId());
 				mitst.setProjectId(itemCopy.getProjectId());
 				mitst.setSourceSystemId(itemCopy.getSourceSystemId());
-				mitst.setStatus(toStatustValueDetail.getTValue());
+				mitst.setStatus(fromStatustValueDetail.getTValue());
 				mitst.setTransitionDate(createDt);
 
 				MetricsItemsTStatusTransition storedTTrans = metricsItemsTStatusTransitionDao.save(mitst);

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/SourceSystemDaoService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/SourceSystemDaoService.java
@@ -1,0 +1,61 @@
+package com.dtcc.workflowmetrics.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.dtcc.workflowmetrics.dao.SourceSystemDao;
+import com.dtcc.workflowmetrics.entity.SourceSystem;
+
+@Service
+public class SourceSystemDaoService {
+
+    @Autowired
+    SourceSystemDao dao;
+
+    public <S extends SourceSystem> S save(S entity) {
+        return dao.save(entity);
+    }
+
+    public <S extends SourceSystem> Iterable<S> saveAll(Iterable<S> entities) {
+        return dao.saveAll(entities);
+    }
+
+    public Optional<SourceSystem> findById(Integer id) {
+        return dao.findById(id);
+    }
+
+    public boolean existsById(Integer id) {
+        return dao.existsById(id);
+    }
+
+    public Iterable<SourceSystem> findAll() {
+        return dao.findAll();
+    }
+
+    public Iterable<SourceSystem> findAllById(Iterable<Integer> ids) {
+        return dao.findAllById(ids);
+    }
+
+    public long count() {
+        return dao.count();
+    }
+
+    public void deleteById(Integer id) {
+        dao.deleteById(id);
+    }
+
+    public void delete(SourceSystem entity) {
+        dao.delete(entity);
+    }
+
+    public void deleteAll(Iterable<? extends SourceSystem> entities) {
+        dao.deleteAll(entities);
+    }
+
+    public void deleteAll() {
+        dao.deleteAll();
+    }
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/StatusDaoService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/StatusDaoService.java
@@ -1,0 +1,58 @@
+package com.dtcc.workflowmetrics.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dtcc.workflowmetrics.dao.StatusCustomFieldDao;
+import com.dtcc.workflowmetrics.dao.StatusDao;
+import com.dtcc.workflowmetrics.dao.StatusTValueDao;
+import com.dtcc.workflowmetrics.entity.EventUser;
+import com.dtcc.workflowmetrics.entity.EventUserCustomField;
+import com.dtcc.workflowmetrics.entity.Status;
+import com.dtcc.workflowmetrics.entity.StatusCustomField;
+import com.dtcc.workflowmetrics.entity.StatusTValue;
+
+@Service
+public class StatusDaoService {
+
+	@Autowired
+	StatusDao statusDao;
+
+	@Autowired
+	StatusTValueDao statusTValueDao;
+
+	@Autowired
+	StatusCustomFieldDao statusCustomFieldDao;
+	
+	@Transactional
+	public Status save(Status status) {
+		
+		Status storedStatusDetail = status;
+		
+		boolean checkData = statusDao.existsStatusByCheckSum(status.getCheckSum());
+
+		if (!checkData) {
+			Status statusCopy = status.clone();
+
+			statusCopy.setLastUpdateDate(System.currentTimeMillis());
+
+			storedStatusDetail = statusDao.save(statusCopy);
+
+			for (StatusCustomField sField : statusCopy.getStatusCustomField()) {
+				sField.setCreateDate(statusCopy.getLastUpdateDate());
+			}
+
+			Iterable<StatusCustomField> storedFields = statusCustomFieldDao.saveAll(statusCopy.getStatusCustomField());
+
+			for (StatusTValue sField : statusCopy.getStatusTValue()) {
+				sField.setCreateDate(statusCopy.getLastUpdateDate());
+			}
+
+			Iterable<StatusTValue> storedTValues = statusTValueDao.saveAll(statusCopy.getStatusTValue());
+		}
+
+		return storedStatusDetail;
+	}
+
+}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/UserHarmonizerService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/UserHarmonizerService.java
@@ -14,6 +14,7 @@ import com.dtcc.workflowmetrics.entity.MetricsItemsStatusTransition;
 import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusTransition;
 import com.dtcc.workflowmetrics.metricsitems.jira.common.CustomField;
 import com.dtcc.workflowmetrics.metricsitems.jira.common.User;
+import com.dtcc.workflowmetrics.metricsitems.jira.issue.Issue;
 import com.dtcc.workflowmetrics.metricsitems.jira.webhook.WebhookData;
 import com.dtcc.workflowmetrics.metricsitems.jira.webhook.WebhookIssue;
 import com.dtcc.workflowmetrics.metricsitems.jira.webhook.WebhookTransition;
@@ -22,23 +23,86 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 public class UserHarmonizerService {
-	
+
 	@Transactional
 	public final MetricsItems harmonizeJira(WebhookData data) {
-		
+
 		EventUser eventUser = harmonizeJiraUser(data.getUser());
-		
+
 		MetricsItems metricItem = harmonizeJiraIssue(data.getTransition(), data.getIssue());
 		return metricItem;
-		
+
 	}
 
-	
+	@Transactional
+	public final MetricsItems harmonizeIssue(Issue issue) {
+
+		int source = 12;
+		MetricsItems item = new MetricsItems();
+
+		item.setItemId(issue.getId());
+		item.setSourceSystemId(source);
+		item.setProjectId(issue.getKey());
+		item.setItemKey(issue.getKey());
+		item.setItemSummary(null);
+		item.setItemDescription(issue.getFields().getDescription());
+		item.setItemCreateDate(Long.getLong(issue.getFields().getCreated()));
+		item.setItemCreator(issue.getFields().getUser().getName());
+		item.setLastUpdateDate(null);
+		item.setLastUpdateUser(issue.getFields().getLastViewed());
+
+		MetricsItemsTStatusTransition tStatusTransition = new MetricsItemsTStatusTransition();
+
+		/*
+		 * tStatusTransition.setItemId(issue.getId());
+		 * tStatusTransition.setProjectId(issue.getKey());
+		 * tStatusTransition.setSourceSystemId(source);
+		 * tStatusTransition.setStatus(Integer.getInteger(issue.getFields().getStatus().
+		 * getId()));
+		 * tStatusTransition.setTransitionDate(Long.getLong(issue.getFields().getCreated
+		 * ()));
+		 * 
+		 * item.addTStatusTransition(tStatusTransition);
+		 * 
+		 * MetricsItemsStatusTransition statusTransition = new
+		 * MetricsItemsStatusTransition();
+		 * 
+		 * statusTransition.setItemId(transition.getTransitionId().toString());
+		 * statusTransition.setProjectId(issue.getFields().getProject().getId().toString
+		 * ()); statusTransition.setSourceSystemId(source);
+		 * statusTransition.setFromStatus(transition.getFrom_status());
+		 * statusTransition.setToStatus(transition.getTo_status());
+		 * statusTransition.setTransitionDate(Long.getLong(issue.getFields().getCreated(
+		 * )));
+		 * 
+		 * item.addStatusTransition(statusTransition);
+		 */
+
+		ArrayList<CustomField> custField = issue.getFields().getCustomFields();
+
+		for (CustomField cust : custField) {
+
+			MetricsItemsCustomField metricCustomField = new MetricsItemsCustomField();
+
+			metricCustomField.setItemId(issue.getId());
+			metricCustomField.setSourceSystemId(source);
+			metricCustomField.setFieldName(cust.getSelf());
+			metricCustomField.setFieldDatatype("CustomField");
+			metricCustomField.setFieldValue(cust.getValue());
+			metricCustomField.setCreateDate(Long.getLong(issue.getFields().getCreated()));
+
+			item.addCustomField(metricCustomField);
+		}
+
+		return item;
+
+	}
+
 	protected final MetricsItems harmonizeJiraIssue(WebhookTransition transition, WebhookIssue issue) {
 
 		int source = 12;
 		MetricsItems item = new MetricsItems();
-		
+
 		item.setItemId(transition.getTransitionId().toString());
 		item.setSourceSystemId(source);
 		item.setProjectId(issue.getFields().getProject().getId().toString());
@@ -49,35 +113,35 @@ public class UserHarmonizerService {
 		item.setItemCreator(issue.getFields().getCreator().getName());
 		item.setLastUpdateDate(null);
 		item.setLastUpdateUser(issue.getFields().getLastViewed());
-		
+
 		MetricsItemsTStatusTransition tStatusTransition = new MetricsItemsTStatusTransition();
-		
+
 		tStatusTransition.setItemId(transition.getTransitionId().toString());
 		tStatusTransition.setProjectId(issue.getFields().getProject().getId().toString());
 		tStatusTransition.setSourceSystemId(source);
-		tStatusTransition.setStatus(Integer.getInteger(issue.getFields().getStatus().getId()));
+		tStatusTransition.setStatus(0);//Integer.getInteger(issue.getFields().getStatus().getId()));
 		tStatusTransition.setTransitionDate(Long.getLong(issue.getFields().getCreated()));
-		
+
 		item.addTStatusTransition(tStatusTransition);
-		
+
 		MetricsItemsStatusTransition statusTransition = new MetricsItemsStatusTransition();
-		
+
 		statusTransition.setItemId(transition.getTransitionId().toString());
 		statusTransition.setProjectId(issue.getFields().getProject().getId().toString());
 		statusTransition.setSourceSystemId(source);
 		statusTransition.setFromStatus(transition.getFrom_status());
 		statusTransition.setToStatus(transition.getTo_status());
 		statusTransition.setTransitionDate(Long.getLong(issue.getFields().getCreated()));
-		
+
 		item.addStatusTransition(statusTransition);
-		
-		Map<String,CustomField> custField = issue.getFields().getCustomFields();
-		
+
+		Map<String, CustomField> custField = issue.getFields().getCustomFields();
+
 		ObjectMapper objectMapper = new ObjectMapper();
 		for (Map.Entry<String, CustomField> cust : custField.entrySet()) {
 
 			MetricsItemsCustomField metricCustomField = new MetricsItemsCustomField();
-			
+
 			metricCustomField.setItemId(transition.getTransitionId().toString());
 			metricCustomField.setSourceSystemId(source);
 			metricCustomField.setFieldName(cust.getKey());
@@ -88,59 +152,60 @@ public class UserHarmonizerService {
 				System.out.println("JSON writing error");
 			}
 			metricCustomField.setCreateDate(Long.getLong(issue.getFields().getCreated()));
-			
+
 			item.addCustomField(metricCustomField);
-		}		
-		
-		
-		
+		}
+
 		return item;
 	}
-	
-	
+
 	protected final EventUser harmonizeJiraUser(User user) {
-		
+
 		int source = 12;
 		EventUser evntUsr = new EventUser();
-		
+
 		evntUsr.setId(user.getKey());
 		evntUsr.setEmailId(user.getEmailAddress());
 		evntUsr.setUserName(user.getName());
 		evntUsr.setSourceSystem(source);
-		
+
 		evntUsr.setLastUpdateDate(setLastUpdateDateforJira(user));
 
 		String checksum = user.getKey() + Integer.toString(source) + user.getEmailAddress() + user.getName();
-		
-		ArrayList<EventUserCustomField> fields= new ArrayList<EventUserCustomField>();
-		
-		EventUserCustomField field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "avatarUrls", "Hashmap", "ConvertAvatarHashmaptoString");
+
+		ArrayList<EventUserCustomField> fields = new ArrayList<EventUserCustomField>();
+
+		EventUserCustomField field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(),
+				"avatarUrls", "Hashmap", "ConvertAvatarHashmaptoString");
 		fields.add(field);
 		checksum = checksum + "avatarUrls" + "Hashmap" + "ConvertAvatarHashmaptoString";
-		
-		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "displayName", "String", user.getDisplayName());
+
+		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "displayName", "String",
+				user.getDisplayName());
 		fields.add(field);
-		
+
 		checksum = checksum + "displayName" + "String" + user.getDisplayName();
-		
-		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "active", "Boolean", user.getActive().toString());
+
+		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "active", "Boolean",
+				user.getActive().toString());
 		fields.add(field);
-		
+
 		checksum = checksum + "active" + "Boolean" + user.getActive().toString();
-		
-		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "timeZone", "String", user.getTimeZone());
+
+		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "timeZone", "String",
+				user.getTimeZone());
 		fields.add(field);
-		
+
 		checksum = checksum + "timeZone" + "String" + user.getTimeZone();
-		
+
 		evntUsr.setCheckSum(checksum);
-		
+
 		evntUsr.setEventUserCustomField(fields);
-		
+
 		return evntUsr;
-		
+
 	}
-	
+
 	private Long setLastUpdateDateforJira(User user) {
 		return System.currentTimeMillis();
 	}

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/UserHarmonizerService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/UserHarmonizerService.java
@@ -15,25 +15,40 @@ public class UserHarmonizerService {
 	@Transactional
 	public final EventUser harmonizeJiraUser(User user) {
 		
+		int source = 12;
 		EventUser evntUsr = new EventUser();
 		
 		evntUsr.setId(user.getKey());
 		evntUsr.setEmailId(user.getEmailAddress());
 		evntUsr.setUserName(user.getName());
-		evntUsr.setSourceSystem(12);
+		evntUsr.setSourceSystem(source);
 		
 		evntUsr.setLastUpdateDate(setLastUpdateDateforJira(user));
 
+		String checksum = user.getKey() + Integer.toString(source) + user.getEmailAddress() + user.getName();
+		
 		ArrayList<EventUserCustomField> fields= new ArrayList<EventUserCustomField>();
 		
 		EventUserCustomField field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "avatarUrls", "Hashmap", "ConvertAvatarHashmaptoString");
 		fields.add(field);
+		checksum = checksum + "avatarUrls" + "Hashmap" + "ConvertAvatarHashmaptoString";
+		
 		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "displayName", "String", user.getDisplayName());
 		fields.add(field);
+		
+		checksum = checksum + "displayName" + "String" + user.getDisplayName();
+		
 		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "active", "Boolean", user.getActive().toString());
 		fields.add(field);
+		
+		checksum = checksum + "active" + "Boolean" + user.getActive().toString();
+		
 		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "timeZone", "String", user.getTimeZone());
 		fields.add(field);
+		
+		checksum = checksum + "timeZone" + "String" + user.getTimeZone();
+		
+		evntUsr.setCheckSum(checksum);
 		
 		evntUsr.setEventUserCustomField(fields);
 		

--- a/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/UserHarmonizerService.java
+++ b/workflowmetrics/src/main/java/com/dtcc/workflowmetrics/service/UserHarmonizerService.java
@@ -1,0 +1,47 @@
+package com.dtcc.workflowmetrics.service;
+
+import java.util.ArrayList;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dtcc.workflowmetrics.entity.EventUser;
+import com.dtcc.workflowmetrics.entity.EventUserCustomField;
+import com.dtcc.workflowmetrics.metricsitems.jira.common.User;
+
+@Service
+public class UserHarmonizerService {
+
+	@Transactional
+	public final EventUser harmonizeJiraUser(User user) {
+		
+		EventUser evntUsr = new EventUser();
+		
+		evntUsr.setId(user.getKey());
+		evntUsr.setEmailId(user.getEmailAddress());
+		evntUsr.setUserName(user.getName());
+		evntUsr.setSourceSystem(12);
+		
+		evntUsr.setLastUpdateDate(setLastUpdateDateforJira(user));
+
+		ArrayList<EventUserCustomField> fields= new ArrayList<EventUserCustomField>();
+		
+		EventUserCustomField field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "avatarUrls", "Hashmap", "ConvertAvatarHashmaptoString");
+		fields.add(field);
+		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "displayName", "String", user.getDisplayName());
+		fields.add(field);
+		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "active", "Boolean", user.getActive().toString());
+		fields.add(field);
+		field = new EventUserCustomField(user.getKey(), 12, evntUsr.getLastUpdateDate(), "timeZone", "String", user.getTimeZone());
+		fields.add(field);
+		
+		evntUsr.setEventUserCustomField(fields);
+		
+		return evntUsr;
+		
+	}
+	
+	private Long setLastUpdateDateforJira(User user) {
+		return System.currentTimeMillis();
+	}
+}

--- a/workflowmetrics/src/main/resources/application.properties
+++ b/workflowmetrics/src/main/resources/application.properties
@@ -8,7 +8,7 @@ server.port = 10000
 #####
 application.outputfile.location = /Users/jiniya.ghosh/jira_output_files
 
-application.user = jiniya
+application.user = dan
 
 ## Spring DATASOURCE (DataSourceAutoConfiguration & DataSourceProperties)
 spring.datasource.url=jdbc:postgresql://localhost:5432/mydb

--- a/workflowmetrics/src/main/resources/application.properties
+++ b/workflowmetrics/src/main/resources/application.properties
@@ -11,7 +11,7 @@ application.outputfile.location = /Users/jiniya.ghosh/jira_output_files
 application.user = dan
 
 ## Spring DATASOURCE (DataSourceAutoConfiguration & DataSourceProperties)
-spring.datasource.url=jdbc:postgresql://localhost:5432/MyDB
+spring.datasource.url=jdbc:postgresql://localhost:5432/mydb
 spring.datasource.username= postgres
 spring.datasource.password= postgres
 

--- a/workflowmetrics/src/main/resources/application.properties
+++ b/workflowmetrics/src/main/resources/application.properties
@@ -8,6 +8,8 @@ server.port = 10000
 #####
 application.outputfile.location = /Users/jiniya.ghosh/jira_output_files
 
+application.user = jiniya
+
 ## Spring DATASOURCE (DataSourceAutoConfiguration & DataSourceProperties)
 spring.datasource.url=jdbc:postgresql://localhost:5432/mydb
 spring.datasource.username= postgres

--- a/workflowmetrics/src/main/resources/application.properties
+++ b/workflowmetrics/src/main/resources/application.properties
@@ -11,7 +11,7 @@ application.outputfile.location = /Users/jiniya.ghosh/jira_output_files
 application.user = dan
 
 ## Spring DATASOURCE (DataSourceAutoConfiguration & DataSourceProperties)
-spring.datasource.url=jdbc:postgresql://localhost:5432/mydb
+spring.datasource.url=jdbc:postgresql://localhost:5432/MyDB
 spring.datasource.username= postgres
 spring.datasource.password= postgres
 

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestMetricsItemsDao.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestMetricsItemsDao.java
@@ -1,6 +1,7 @@
 package com.dtcc.workflowmetrics.dao;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -14,23 +15,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.dtcc.workflowmetrics.entity.Project;
+import com.dtcc.workflowmetrics.entity.MetricsItems;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class TestProjectDao {
+public class TestMetricsItemsDao {
 
     @Autowired
-    ProjectDao dao;
+    MetricsItemsDao dao;
 
-    private static Project CM = (new Project()).setId("CM").setKey("CM").setLast_update_date(System.currentTimeMillis())
-            .setName("Company Management").setSourceSystemId(1).setChecksum("");
-    private static Project METRICS = (new Project()).setId("METRICS").setKey("METRICS").setLast_update_date(System.currentTimeMillis())
-            .setName("Metrics KPIs and Displays").setSourceSystemId(1).setChecksum("");
-    private static Project DEVELOPMENT = (new Project()).setId("DEVELOPMENT").setKey("DEVELOPMENT").setLast_update_date(System.currentTimeMillis())
-            .setName("Software Application Development").setSourceSystemId(1).setChecksum("");
-    private ArrayList<Project> projects = new ArrayList<Project>();
-
+    private static MetricsItems mi1 = (new MetricsItems()).setItemId("Item1").setLastUpdateDate(System.currentTimeMillis()).setItemCreator("itemCreator1")
+    		.setItemCreateDate(System.currentTimeMillis()).setItemSummary("itemSummary1").setCheckSum("").setItemKey("itemKey1").setLastUpdateUser("user1");
+    private static MetricsItems mi2 = (new MetricsItems()).setItemId("Item2").setLastUpdateDate(System.currentTimeMillis()).setItemCreator("itemCreator2")
+    		.setItemCreateDate(System.currentTimeMillis()).setItemSummary("itemSummary2").setCheckSum("").setItemKey("itemKey2").setLastUpdateUser("user2");
+    private static MetricsItems mi3 = (new MetricsItems()).setItemId("Item3").setLastUpdateDate(System.currentTimeMillis()).setItemCreator("itemCreator3")
+    		.setItemCreateDate(System.currentTimeMillis()).setItemSummary("itemSummary3").setCheckSum("").setItemKey("itemKey3").setLastUpdateUser("user3");
+    private ArrayList<MetricsItems> metricsItems = new ArrayList<MetricsItems>();
+    
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
     }
@@ -42,10 +43,10 @@ public class TestProjectDao {
     @Before
     public void setUp() throws Exception {
         dao.deleteAll();
-        projects.removeAll(projects);
-        projects.add(CM);
-        projects.add(METRICS);
-        projects.add(DEVELOPMENT);
+        metricsItems.removeAll(metricsItems);
+        metricsItems.add(mi1);
+        metricsItems.add(mi2);
+        metricsItems.add(mi3);
     }
 
     @After
@@ -54,9 +55,9 @@ public class TestProjectDao {
 
     @Test
     public void testSave() {
-        Project savedProject = dao.save(CM);
-        assertEquals(CM, savedProject);
-        System.out.println(CM.getChecksum());
+    	MetricsItems savedMetricsItems = dao.save(mi1);
+        assertEquals(mi1, savedMetricsItems);
+        System.out.println(mi1.getCheckSum());
     }
 
     @Test

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestProjectDao.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestProjectDao.java
@@ -24,11 +24,11 @@ public class TestProjectDao {
     ProjectDao dao;
 
     private static Project CM = (new Project()).setId("CM").setKey("CM").setLast_update_date(System.currentTimeMillis())
-            .setName("Company Management").setSourceSystemId(1);
+            .setName("Company Management").setSourceSystemId(1).setChecksum("");
     private static Project METRICS = (new Project()).setId("METRICS").setKey("METRICS").setLast_update_date(System.currentTimeMillis())
-            .setName("Metrics KPIs and Displays").setSourceSystemId(1);
+            .setName("Metrics KPIs and Displays").setSourceSystemId(1).setChecksum("");
     private static Project DEVELOPMENT = (new Project()).setId("DEVELOPMENT").setKey("DEVELOPMENT").setLast_update_date(System.currentTimeMillis())
-            .setName("Software Application Development").setSourceSystemId(1);
+            .setName("Software Application Development").setSourceSystemId(1).setChecksum("");
     private ArrayList<Project> projects = new ArrayList<Project>();
     
     @BeforeClass
@@ -56,6 +56,7 @@ public class TestProjectDao {
     public void testSave() {
         Project savedProject = dao.save(CM);
         assertEquals(CM, savedProject);
+        System.out.println(CM.getChecksum());
     }
 
     @Test

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestProjectDao.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestProjectDao.java
@@ -1,0 +1,111 @@
+package com.dtcc.workflowmetrics.dao;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.dtcc.workflowmetrics.entity.Project;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TestProjectDao {
+
+    @Autowired
+    ProjectDao dao;
+
+    private static Project CM = (new Project()).setId("CM").setKey("CM").setLast_update_date(System.currentTimeMillis())
+            .setName("Company Management").setSourceSystemId(1);
+    private static Project METRICS = (new Project()).setId("METRICS").setKey("METRICS").setLast_update_date(System.currentTimeMillis())
+            .setName("Metrics KPIs and Displays").setSourceSystemId(1);
+    private static Project DEVELOPMENT = (new Project()).setId("DEVELOPMENT").setKey("DEVELOPMENT").setLast_update_date(System.currentTimeMillis())
+            .setName("Software Application Development").setSourceSystemId(1);
+    private ArrayList<Project> projects = new ArrayList<Project>();
+    
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        dao.deleteAll();
+        projects.removeAll(projects);
+        projects.add(CM);
+        projects.add(METRICS);
+        projects.add(DEVELOPMENT);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testSave() {
+        Project savedProject = dao.save(CM);
+        assertEquals(CM, savedProject);
+    }
+
+    @Test
+    public void testSaveAll() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testFindById() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testExistsById() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testFindAll() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testFindAllById() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testCount() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testDeleteById() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testDelete() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testDeleteAllIterableOfQextendsT() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    public void testDeleteAll() {
+        fail("Not yet implemented");
+    }
+
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestSourceSystemDao.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestSourceSystemDao.java
@@ -1,0 +1,194 @@
+package com.dtcc.workflowmetrics.dao;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.dtcc.workflowmetrics.entity.SourceSystem;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TestSourceSystemDao {
+    
+    @Autowired
+    SourceSystemDao dao;
+    
+    private static final SourceSystem JIRA = new SourceSystem(1, "Jira");
+    private static final SourceSystem SNOW = new SourceSystem(2, "SNOW");
+    private static final SourceSystem SERENA = new SourceSystem(3, "SERENA");
+    
+    private static final ArrayList<SourceSystem> sourceSystems = new ArrayList<SourceSystem>();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        dao.deleteAll();
+        sourceSystems.removeAll(sourceSystems);
+        sourceSystems.add(JIRA);
+        sourceSystems.add(SNOW);
+        sourceSystems.add(SERENA);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testSave() {
+        SourceSystem newJira = dao.save(JIRA);
+        
+        assertEquals(JIRA.getId(), newJira.getId());
+        assertEquals(JIRA.getDescription(), newJira.getDescription());
+    }
+
+    @Test
+    public void testSaveAll() {
+        
+        Iterable<SourceSystem> savedSourceSystems = dao.saveAll(sourceSystems);
+        compareListWithReturnList(sourceSystems, savedSourceSystems);
+    }
+
+    @Test
+    public void testFindById() {
+        dao.saveAll(sourceSystems);
+        Optional<SourceSystem> optS = dao.findById(JIRA.getId().intValue());
+        SourceSystem s = optS.get();
+        assertEquals(JIRA, s);
+    }
+
+    @Test
+    public void testExistsById() {
+        dao.saveAll(sourceSystems);
+        assertTrue(dao.existsById(JIRA.getId()));
+        assertFalse(dao.existsById(Integer.valueOf(-1)));
+    }
+
+    @Test
+    public void testFindAll() {
+        dao.saveAll(sourceSystems);
+        Iterable<SourceSystem> savedSourceSystems = dao.findAll();
+
+        compareListWithReturnList(sourceSystems, savedSourceSystems);
+        
+    }
+
+    @Test
+    public void testFindAllById() {
+        dao.saveAll(sourceSystems);
+        
+        ArrayList<Integer> ids = new ArrayList<Integer>();
+        
+        for (SourceSystem s : sourceSystems) {
+            ids.add(Integer.valueOf(s.getId()));
+        }
+        
+        Iterable<SourceSystem> savedSourceSystems = dao.findAllById(ids);
+        compareListWithReturnList(sourceSystems, savedSourceSystems);
+    }
+
+    @Test
+    public void testCount() {
+        dao.saveAll(sourceSystems);
+        assertEquals(sourceSystems.size(), dao.count());
+    }
+
+    @Test
+    public void testDeleteById() {
+        dao.saveAll(sourceSystems);
+        dao.deleteById(JIRA.getId());
+        Iterable<SourceSystem> sss = dao.findAll();
+        ArrayList<SourceSystem> sssa = new ArrayList<SourceSystem>();
+        sss.forEach(sssa::add);
+        assertEquals(sourceSystems.size() - 1, sssa.size());
+        for (SourceSystem s : sourceSystems) {
+            if (s.equals(JIRA)) {
+                assertFalse(sssa.contains(s));
+            } else {
+                assertTrue(sssa.contains(s));
+            }
+        }
+    }
+
+    @Test
+    public void testDelete() {
+        dao.saveAll(sourceSystems);
+        dao.delete(JIRA);
+        Iterable<SourceSystem> rss = dao.findAll();
+        ArrayList<SourceSystem> rssa = new ArrayList<SourceSystem>();
+        rss.forEach(rssa::add);
+        
+        for (SourceSystem s : sourceSystems) {
+            if (s.equals(JIRA)) {
+                assertFalse(rssa.contains(s));
+            } else {
+                assertTrue(rssa.contains(s));
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteAllIterableOfQextendsT() {
+        dao.saveAll(sourceSystems);
+        ArrayList<SourceSystem> deletableSystems = new ArrayList<SourceSystem>();
+        
+        deletableSystems.add(JIRA);
+        deletableSystems.add(SNOW);
+        
+        dao.deleteAll(deletableSystems);
+        Iterable<SourceSystem> rss = dao.findAll();
+        ArrayList<SourceSystem> rssa = new ArrayList<SourceSystem>();
+        rss.forEach(rssa::add);
+        
+        for (SourceSystem s : sourceSystems) {
+            if (s.equals(JIRA) || s.equals(SNOW)) {
+                assertFalse(rssa.contains(s));
+            } else {
+                assertTrue(rssa.contains(s));
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteAll() {
+        dao.saveAll(sourceSystems);
+        dao.deleteAll();
+        assertEquals(0, dao.count());
+    }
+    
+    private void compareListWithReturnList(Iterable<SourceSystem> originalList, Iterable<SourceSystem> returnedList) {
+        ArrayList<SourceSystem> originalArray = new ArrayList<SourceSystem>();
+        originalList.forEach(originalArray::add);
+        ArrayList<SourceSystem> returnedArray = new ArrayList<SourceSystem>();
+        returnedList.forEach(returnedArray::add);
+        
+        ArrayList<SourceSystem> inOriginalButNotInReturned = new ArrayList<SourceSystem>(originalArray);
+        ArrayList<SourceSystem> inReturnedButNotInOriginal = new ArrayList<SourceSystem>(returnedArray);
+        
+        inOriginalButNotInReturned.removeAll(returnedArray);
+        inReturnedButNotInOriginal.removeAll(originalArray);
+        
+        assertEquals(0, inOriginalButNotInReturned.size());
+        assertEquals(0, inReturnedButNotInOriginal.size());
+    }
+
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestSourceSystemDao.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestSourceSystemDao.java
@@ -1,9 +1,10 @@
 package com.dtcc.workflowmetrics.dao;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Optional;
 
 import org.junit.After;

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestStatusDao.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/dao/TestStatusDao.java
@@ -1,6 +1,7 @@
 package com.dtcc.workflowmetrics.dao;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 
@@ -14,23 +15,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.dtcc.workflowmetrics.entity.Project;
+import com.dtcc.workflowmetrics.entity.Status;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class TestProjectDao {
+public class TestStatusDao {
 
     @Autowired
-    ProjectDao dao;
+    StatusDao dao;
 
-    private static Project CM = (new Project()).setId("CM").setKey("CM").setLast_update_date(System.currentTimeMillis())
-            .setName("Company Management").setSourceSystemId(1).setChecksum("");
-    private static Project METRICS = (new Project()).setId("METRICS").setKey("METRICS").setLast_update_date(System.currentTimeMillis())
-            .setName("Metrics KPIs and Displays").setSourceSystemId(1).setChecksum("");
-    private static Project DEVELOPMENT = (new Project()).setId("DEVELOPMENT").setKey("DEVELOPMENT").setLast_update_date(System.currentTimeMillis())
-            .setName("Software Application Development").setSourceSystemId(1).setChecksum("");
-    private ArrayList<Project> projects = new ArrayList<Project>();
-
+    private static Status st1 = (new Status()).setStatusId("statusId1").setSourceSystemId(12).setDescription("description1").setCheckSum("").setName("name1").setLastUpdateDate(System.currentTimeMillis());
+    private static Status st2 = (new Status()).setStatusId("statusId2").setSourceSystemId(12).setDescription("description2").setCheckSum("").setName("name2").setLastUpdateDate(System.currentTimeMillis());
+    private static Status st3 = (new Status()).setStatusId("statusId3").setSourceSystemId(12).setDescription("description3").setCheckSum("").setName("name3").setLastUpdateDate(System.currentTimeMillis());
+    private ArrayList<Status> status = new ArrayList<Status>();
+    
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
     }
@@ -42,10 +40,10 @@ public class TestProjectDao {
     @Before
     public void setUp() throws Exception {
         dao.deleteAll();
-        projects.removeAll(projects);
-        projects.add(CM);
-        projects.add(METRICS);
-        projects.add(DEVELOPMENT);
+        status.removeAll(status);
+        status.add(st1);
+        status.add(st2);
+        status.add(st3);
     }
 
     @After
@@ -54,9 +52,9 @@ public class TestProjectDao {
 
     @Test
     public void testSave() {
-        Project savedProject = dao.save(CM);
-        assertEquals(CM, savedProject);
-        System.out.println(CM.getChecksum());
+        Status savedStatus = dao.save(st1);
+        assertEquals(st1, savedStatus);
+        System.out.println(st1.getCheckSum());
     }
 
     @Test

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/service/TestMetricsItemDaoService.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/service/TestMetricsItemDaoService.java
@@ -1,0 +1,127 @@
+package com.dtcc.workflowmetrics.service;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.dtcc.workflowmetrics.dao.MetricsItemsDao;
+import com.dtcc.workflowmetrics.entity.MetricsItems;
+import com.dtcc.workflowmetrics.entity.MetricsItemsCustomField;
+import com.dtcc.workflowmetrics.entity.MetricsItemsStatusDuration;
+import com.dtcc.workflowmetrics.entity.MetricsItemsStatusTransition;
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusDuration;
+import com.dtcc.workflowmetrics.entity.MetricsItemsTStatusTransition;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TestMetricsItemDaoService {
+
+	@Mock
+	private MetricsItemsDao dao;
+
+	@InjectMocks
+	MetricsItemsDaoService daoSvc = new MetricsItemsDaoService();
+
+	static long dt = System.currentTimeMillis();
+
+	private static final MetricsItemsCustomField cust1 = new MetricsItemsCustomField("1", 1, dt, "customfield_10101",
+			"String", "1|hzyuen:");
+	private static final MetricsItemsCustomField cust2 = new MetricsItemsCustomField("2", 1, dt, "customfield_18904",
+			"String", null);
+
+	private static final ArrayList<MetricsItemsCustomField> customFields = new ArrayList<MetricsItemsCustomField>();
+
+	private static final MetricsItemsStatusTransition mist1 = new MetricsItemsStatusTransition("1", "JIRA1", 1, "new",
+			"groomed", dt);
+	private static final MetricsItemsStatusTransition mist2 = new MetricsItemsStatusTransition("2", "JIRA1", 1,
+			"groomed", "ready for development", dt);
+
+	private static final ArrayList<MetricsItemsStatusTransition> statusTransitions = new ArrayList<MetricsItemsStatusTransition>();
+
+	private static final MetricsItemsStatusDuration misd1 = new MetricsItemsStatusDuration("1", "JIRA1", 1, "new",
+			Long.valueOf("2"));
+	private static final MetricsItemsStatusDuration misd2 = new MetricsItemsStatusDuration("1", "JIRA1", 1, "new",
+			Long.valueOf("2"));
+
+	private static final ArrayList<MetricsItemsStatusDuration> statusDurations = new ArrayList<MetricsItemsStatusDuration>();
+
+	private static final MetricsItemsTStatusTransition mitst1 = new MetricsItemsTStatusTransition("1", "JIRA1", 1, 0,
+			dt);
+	private static final MetricsItemsTStatusTransition mitst2 = new MetricsItemsTStatusTransition("2", "JIRA1", 1, 1,
+			dt);
+
+	private static final ArrayList<MetricsItemsTStatusTransition> tStatusTransitions = new ArrayList<MetricsItemsTStatusTransition>();
+
+	private static final MetricsItemsTStatusDuration mitsd1 = new MetricsItemsTStatusDuration("1", "JIRA1", 1, 0,
+			Long.valueOf("2"));
+	private static final MetricsItemsTStatusDuration mitsd2 = new MetricsItemsTStatusDuration("1", "JIRA1", 1, 1,
+			Long.valueOf("3"));
+
+	private static final ArrayList<MetricsItemsTStatusDuration> tStatusDurations = new ArrayList<MetricsItemsTStatusDuration>();
+
+	private static MetricsItems item1;
+	 
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		//daoSvc.deleteAll();
+
+		customFields.removeAll(customFields);
+		customFields.add(cust1);
+		customFields.add(cust2);
+
+		statusTransitions.removeAll(statusTransitions);
+		statusTransitions.add(mist1);
+		statusTransitions.add(mist2);
+
+		statusDurations.removeAll(statusDurations);
+		statusDurations.add(misd1);
+		statusDurations.add(misd2);
+
+		tStatusTransitions.removeAll(tStatusTransitions);
+		tStatusTransitions.add(mitst1);
+		tStatusTransitions.add(mitst2);
+
+		tStatusDurations.removeAll(tStatusDurations);
+		tStatusDurations.add(mitsd1);
+		tStatusDurations.add(mitsd2);
+
+		item1 = new MetricsItems("1", 1, "item1", "JIRA1", "MetricsItemTest1", "MetricsItemTest1",
+				dt, "Tester1", dt, "Tester1", customFields, tStatusTransitions, statusTransitions, statusDurations,
+				tStatusDurations);
+
+	}
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void testSave() {
+		MetricsItems newItem = daoSvc.save(item1);
+
+		assertEquals(item1.getItemId(), newItem.getItemId());
+		assertEquals(item1.getItemKey(), newItem.getItemKey());
+	}
+
+
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/service/TestSourceSystemDaoService.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/service/TestSourceSystemDaoService.java
@@ -1,6 +1,8 @@
 package com.dtcc.workflowmetrics.service;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -13,11 +15,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.AdditionalMatchers;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/service/TestSourceSystemDaoService.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/service/TestSourceSystemDaoService.java
@@ -1,8 +1,10 @@
 package com.dtcc.workflowmetrics.service;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.junit.After;
@@ -11,28 +13,36 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.AdditionalMatchers;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.dtcc.workflowmetrics.dao.SourceSystemDao;
 import com.dtcc.workflowmetrics.entity.SourceSystem;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class TestSourceSystemDaoService {
 
-    @Autowired
-    SourceSystemDaoService daoSvc;
-    
+    @Mock
+    private SourceSystemDao dao;
+
+    @InjectMocks
+    SourceSystemDaoService daoSvc = new SourceSystemDaoService();
+
     private static final SourceSystem JIRA = new SourceSystem(1, "Jira");
     private static final SourceSystem SNOW = new SourceSystem(2, "SNOW");
     private static final SourceSystem SERENA = new SourceSystem(3, "SERENA");
-    
+
     private static final ArrayList<SourceSystem> sourceSystems = new ArrayList<SourceSystem>();
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        
+
     }
 
     @AfterClass
@@ -46,6 +56,11 @@ public class TestSourceSystemDaoService {
         sourceSystems.add(JIRA);
         sourceSystems.add(SNOW);
         sourceSystems.add(SERENA);
+
+        when(dao.findById(JIRA.getId())).thenReturn(Optional.of(JIRA));
+        when(dao.findById(SNOW.getId())).thenReturn(Optional.of(SNOW));
+        when(dao.findById(SERENA.getId())).thenReturn(Optional.of(SERENA));
+
     }
 
     @After
@@ -55,14 +70,14 @@ public class TestSourceSystemDaoService {
     @Test
     public void testSave() {
         SourceSystem newJira = daoSvc.save(JIRA);
-        
+
         assertEquals(JIRA.getId(), newJira.getId());
         assertEquals(JIRA.getDescription(), newJira.getDescription());
     }
 
     @Test
     public void testSaveAll() {
-        
+
         Iterable<SourceSystem> savedSourceSystems = daoSvc.saveAll(sourceSystems);
         compareListWithReturnList(sourceSystems, savedSourceSystems);
     }
@@ -73,6 +88,20 @@ public class TestSourceSystemDaoService {
         Optional<SourceSystem> optS = daoSvc.findById(JIRA.getId().intValue());
         SourceSystem s = optS.get();
         assertEquals(JIRA, s);
+
+        optS = daoSvc.findById(SERENA.getId().intValue());
+        s = optS.get();
+        assertEquals(SERENA, s);
+
+        Boolean failed = true;
+        try {
+            optS = daoSvc.findById(1000);
+            s = optS.get();
+        } catch (NoSuchElementException e) {
+         failed = false;   
+        }
+        assertFalse(failed);
+        
     }
 
     @Test
@@ -88,19 +117,19 @@ public class TestSourceSystemDaoService {
         Iterable<SourceSystem> savedSourceSystems = daoSvc.findAll();
 
         compareListWithReturnList(sourceSystems, savedSourceSystems);
-        
+
     }
 
     @Test
     public void testFindAllById() {
         daoSvc.saveAll(sourceSystems);
-        
+
         ArrayList<Integer> ids = new ArrayList<Integer>();
-        
+
         for (SourceSystem s : sourceSystems) {
             ids.add(Integer.valueOf(s.getId()));
         }
-        
+
         Iterable<SourceSystem> savedSourceSystems = daoSvc.findAllById(ids);
         compareListWithReturnList(sourceSystems, savedSourceSystems);
     }
@@ -135,7 +164,7 @@ public class TestSourceSystemDaoService {
         Iterable<SourceSystem> rss = daoSvc.findAll();
         ArrayList<SourceSystem> rssa = new ArrayList<SourceSystem>();
         rss.forEach(rssa::add);
-        
+
         for (SourceSystem s : sourceSystems) {
             if (s.equals(JIRA)) {
                 assertFalse(rssa.contains(s));
@@ -149,15 +178,15 @@ public class TestSourceSystemDaoService {
     public void testDeleteAllIterableOfQextendsT() {
         daoSvc.saveAll(sourceSystems);
         ArrayList<SourceSystem> deletableSystems = new ArrayList<SourceSystem>();
-        
+
         deletableSystems.add(JIRA);
         deletableSystems.add(SNOW);
-        
+
         daoSvc.deleteAll(deletableSystems);
         Iterable<SourceSystem> rss = daoSvc.findAll();
         ArrayList<SourceSystem> rssa = new ArrayList<SourceSystem>();
         rss.forEach(rssa::add);
-        
+
         for (SourceSystem s : sourceSystems) {
             if (s.equals(JIRA) || s.equals(SNOW)) {
                 assertFalse(rssa.contains(s));
@@ -173,19 +202,19 @@ public class TestSourceSystemDaoService {
         daoSvc.deleteAll();
         assertEquals(0, daoSvc.count());
     }
-    
+
     private void compareListWithReturnList(Iterable<SourceSystem> originalList, Iterable<SourceSystem> returnedList) {
         ArrayList<SourceSystem> originalArray = new ArrayList<SourceSystem>();
         originalList.forEach(originalArray::add);
         ArrayList<SourceSystem> returnedArray = new ArrayList<SourceSystem>();
         returnedList.forEach(returnedArray::add);
-        
+
         ArrayList<SourceSystem> inOriginalButNotInReturned = new ArrayList<SourceSystem>(originalArray);
         ArrayList<SourceSystem> inReturnedButNotInOriginal = new ArrayList<SourceSystem>(returnedArray);
-        
+
         inOriginalButNotInReturned.removeAll(returnedArray);
         inReturnedButNotInOriginal.removeAll(originalArray);
-        
+
         assertEquals(0, inOriginalButNotInReturned.size());
         assertEquals(0, inReturnedButNotInOriginal.size());
     }

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/service/TestSourceSystemDaoService.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/service/TestSourceSystemDaoService.java
@@ -1,0 +1,193 @@
+package com.dtcc.workflowmetrics.service;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.dtcc.workflowmetrics.entity.SourceSystem;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TestSourceSystemDaoService {
+
+    @Autowired
+    SourceSystemDaoService daoSvc;
+    
+    private static final SourceSystem JIRA = new SourceSystem(1, "Jira");
+    private static final SourceSystem SNOW = new SourceSystem(2, "SNOW");
+    private static final SourceSystem SERENA = new SourceSystem(3, "SERENA");
+    
+    private static final ArrayList<SourceSystem> sourceSystems = new ArrayList<SourceSystem>();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        daoSvc.deleteAll();
+        sourceSystems.removeAll(sourceSystems);
+        sourceSystems.add(JIRA);
+        sourceSystems.add(SNOW);
+        sourceSystems.add(SERENA);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testSave() {
+        SourceSystem newJira = daoSvc.save(JIRA);
+        
+        assertEquals(JIRA.getId(), newJira.getId());
+        assertEquals(JIRA.getDescription(), newJira.getDescription());
+    }
+
+    @Test
+    public void testSaveAll() {
+        
+        Iterable<SourceSystem> savedSourceSystems = daoSvc.saveAll(sourceSystems);
+        compareListWithReturnList(sourceSystems, savedSourceSystems);
+    }
+
+    @Test
+    public void testFindById() {
+        daoSvc.saveAll(sourceSystems);
+        Optional<SourceSystem> optS = daoSvc.findById(JIRA.getId().intValue());
+        SourceSystem s = optS.get();
+        assertEquals(JIRA, s);
+    }
+
+    @Test
+    public void testExistsById() {
+        daoSvc.saveAll(sourceSystems);
+        assertTrue(daoSvc.existsById(JIRA.getId()));
+        assertFalse(daoSvc.existsById(Integer.valueOf(-1)));
+    }
+
+    @Test
+    public void testFindAll() {
+        daoSvc.saveAll(sourceSystems);
+        Iterable<SourceSystem> savedSourceSystems = daoSvc.findAll();
+
+        compareListWithReturnList(sourceSystems, savedSourceSystems);
+        
+    }
+
+    @Test
+    public void testFindAllById() {
+        daoSvc.saveAll(sourceSystems);
+        
+        ArrayList<Integer> ids = new ArrayList<Integer>();
+        
+        for (SourceSystem s : sourceSystems) {
+            ids.add(Integer.valueOf(s.getId()));
+        }
+        
+        Iterable<SourceSystem> savedSourceSystems = daoSvc.findAllById(ids);
+        compareListWithReturnList(sourceSystems, savedSourceSystems);
+    }
+
+    @Test
+    public void testCount() {
+        daoSvc.saveAll(sourceSystems);
+        assertEquals(sourceSystems.size(), daoSvc.count());
+    }
+
+    @Test
+    public void testDeleteById() {
+        daoSvc.saveAll(sourceSystems);
+        daoSvc.deleteById(JIRA.getId());
+        Iterable<SourceSystem> sss = daoSvc.findAll();
+        ArrayList<SourceSystem> sssa = new ArrayList<SourceSystem>();
+        sss.forEach(sssa::add);
+        assertEquals(sourceSystems.size() - 1, sssa.size());
+        for (SourceSystem s : sourceSystems) {
+            if (s.equals(JIRA)) {
+                assertFalse(sssa.contains(s));
+            } else {
+                assertTrue(sssa.contains(s));
+            }
+        }
+    }
+
+    @Test
+    public void testDelete() {
+        daoSvc.saveAll(sourceSystems);
+        daoSvc.delete(JIRA);
+        Iterable<SourceSystem> rss = daoSvc.findAll();
+        ArrayList<SourceSystem> rssa = new ArrayList<SourceSystem>();
+        rss.forEach(rssa::add);
+        
+        for (SourceSystem s : sourceSystems) {
+            if (s.equals(JIRA)) {
+                assertFalse(rssa.contains(s));
+            } else {
+                assertTrue(rssa.contains(s));
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteAllIterableOfQextendsT() {
+        daoSvc.saveAll(sourceSystems);
+        ArrayList<SourceSystem> deletableSystems = new ArrayList<SourceSystem>();
+        
+        deletableSystems.add(JIRA);
+        deletableSystems.add(SNOW);
+        
+        daoSvc.deleteAll(deletableSystems);
+        Iterable<SourceSystem> rss = daoSvc.findAll();
+        ArrayList<SourceSystem> rssa = new ArrayList<SourceSystem>();
+        rss.forEach(rssa::add);
+        
+        for (SourceSystem s : sourceSystems) {
+            if (s.equals(JIRA) || s.equals(SNOW)) {
+                assertFalse(rssa.contains(s));
+            } else {
+                assertTrue(rssa.contains(s));
+            }
+        }
+    }
+
+    @Test
+    public void testDeleteAll() {
+        daoSvc.saveAll(sourceSystems);
+        daoSvc.deleteAll();
+        assertEquals(0, daoSvc.count());
+    }
+    
+    private void compareListWithReturnList(Iterable<SourceSystem> originalList, Iterable<SourceSystem> returnedList) {
+        ArrayList<SourceSystem> originalArray = new ArrayList<SourceSystem>();
+        originalList.forEach(originalArray::add);
+        ArrayList<SourceSystem> returnedArray = new ArrayList<SourceSystem>();
+        returnedList.forEach(returnedArray::add);
+        
+        ArrayList<SourceSystem> inOriginalButNotInReturned = new ArrayList<SourceSystem>(originalArray);
+        ArrayList<SourceSystem> inReturnedButNotInOriginal = new ArrayList<SourceSystem>(returnedArray);
+        
+        inOriginalButNotInReturned.removeAll(returnedArray);
+        inReturnedButNotInOriginal.removeAll(originalArray);
+        
+        assertEquals(0, inOriginalButNotInReturned.size());
+        assertEquals(0, inReturnedButNotInOriginal.size());
+    }
+
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/DataObjectTester.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/DataObjectTester.java
@@ -42,7 +42,6 @@ public class DataObjectTester {
                     // For the list of parameters, construct a list of hashmaps of DataObjectTesterParameters to be used to test the constructor
                     HashMap<Integer, DataObjectTesterParameter> parameterMap = buildParameterHashmap(parameters);
                     
-                    System.out.println("Constructor parameter count:  " + c.getParameterCount());
                     System.out.println("Parameter Map:  " + parameterMap.toString());
                 }
             } catch (Exception e) {

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/DataObjectTester.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/DataObjectTester.java
@@ -1,0 +1,86 @@
+package com.dtcc.workflowmetrics.test.util;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class DataObjectTester {
+    
+    private static final ValueProviders providers = new ValueProviders();
+
+    public void testPassedClasses(String[] classes) {
+        
+        testPassedClasses(new ArrayList<String>(Arrays.asList(classes)));
+
+    }
+
+    public void testPassedClasses(ArrayList<String> classes) {
+
+        // Loop through the classes, and test each one
+        for (String className : classes) {
+
+            // Get a Class instance for each class passed
+            try {
+                Class classToBeTested = Class.forName(className);
+
+                // Get Constructors for the class, so that we can validate the constructor, and
+                // instantiate the class
+                Constructor[] constructors = classToBeTested.getConstructors();
+
+                // For each constructor, instantiate the class
+                for (Constructor c : constructors) {
+
+                    // Get the arguments for the constructor
+                    Parameter[] parameters = c.getParameters();
+                    
+                    // For the list of parameters, construct a list of hashmaps of DataObjectTesterParameters to be used to test the constructor
+                    HashMap<Integer, DataObjectTesterParameter> parameterMap = buildParameterHashmap(parameters);
+                    
+                    System.out.println("Constructor parameter count:  " + c.getParameterCount());
+                    System.out.println("Parameter Map:  " + parameterMap.toString());
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private HashMap<Integer, DataObjectTesterParameter> buildParameterHashmap(Parameter[] parameters) {
+        int parameterCount = 0;
+        Integer parameterPosition;
+        HashMap<Integer, DataObjectTesterParameter> parameterMap = new HashMap<Integer, DataObjectTesterParameter>();
+        
+        
+        for (Parameter p : parameters) {
+            parameterPosition = Integer.valueOf(parameterCount);
+            parameterCount++;
+            
+            DataObjectTesterParameter dotp = new DataObjectTesterParameter(p.getType(), providers.getProvider(p.getType()).get());
+            
+            parameterMap.put(parameterPosition, dotp);
+        }
+        
+        return parameterMap;
+    }
+
+    private ArrayList<Method> getMethods(String className) {
+
+        ArrayList<Method> methods = new ArrayList<Method>();
+
+        try {
+            methods = new ArrayList<Method>(Arrays.asList(Class.forName(className).getMethods()));
+        } catch (ClassNotFoundException e) {
+            // Want to log that the class didn't exist, but we can continue with an empty
+            // method array.
+            // throw new RuntimeException(e);
+        }
+
+        return methods;
+    }
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/DataObjectTesterParameter.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/DataObjectTesterParameter.java
@@ -1,0 +1,136 @@
+package com.dtcc.workflowmetrics.test.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
+
+import java.util.Set;
+
+import org.assertj.core.util.Arrays;
+
+import antlr.collections.List;
+
+public class DataObjectTesterParameter {
+    private Class objectClass;
+    private Object value;
+    
+    public DataObjectTesterParameter(Class clazz, Object value) {
+        this.objectClass = clazz;
+        this.value = value;
+    }
+    
+    public Class getObjectClass() {
+        return this.objectClass;
+    }
+    
+    public Object getValue() {
+        return this.value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((objectClass == null) ? 0 : objectClass.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        DataObjectTesterParameter other = (DataObjectTesterParameter) obj;
+        if (objectClass == null) {
+            if (other.objectClass != null) {
+                return false;
+            }
+        } else if (!objectClass.getCanonicalName().equals(other.objectClass.getCanonicalName())) {
+            return false;
+        }
+        if (value == null) {
+            if (other.value != null) {
+                return false;
+            }
+        } else if (!value.equals(other.value)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("DataObjectTesterParameter [objectClass=");
+        builder.append(objectClass);
+        builder.append(", value=");
+        builder.append(valueToString(value));
+        builder.append("]");
+        return builder.toString();
+    }
+
+    private String valueToString(Object o) {
+        
+        System.out.println("Object class:  " + o.getClass().getCanonicalName());
+       
+        StringBuilder sb = new StringBuilder();
+        
+        if (o instanceof Iterable) {
+            Iterator<Object> i = ((Iterable<Object>) o).iterator();
+            return iterableToString(i);
+        }
+        
+        if (o instanceof Map) {
+            Map map = (Map) o;
+            sb.append("[");
+            Set keySet = map.keySet();
+            Iterator i = keySet.iterator();
+            Object obj;
+            if (i.hasNext()) {
+                obj = i.next();
+                sb.append("{" + obj.toString() + ", " + map.get(obj).toString());
+            }
+            while (i.hasNext()) {
+                obj = i.next();
+                sb.append("}, {" + obj.toString() + ", " + map.get(obj).toString());
+            }
+            if (!keySet.isEmpty()) {
+                sb.append("}");
+            }
+            sb.append("]");
+            return sb.toString();
+        }
+        
+        if (null != o && o.getClass().isArray()) {
+            System.out.println("Got Here!");
+           ArrayList l = new ArrayList(Arrays.asList(o));
+           Iterator<Object> i = l.iterator();
+           return iterableToString(i);
+        }
+        
+        return sb.toString();
+    }
+    
+    private String iterableToString(Iterator i) {
+        
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");        
+        
+        if (i.hasNext()) {
+            sb.append(i.next().toString());
+        }
+        while (i.hasNext()) {
+            sb.append(", " + i.next().toString());
+        }
+        sb.append("]");
+        
+        return sb.toString();   
+    }
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/DataObjectTesterParameter.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/DataObjectTesterParameter.java
@@ -13,16 +13,16 @@ import antlr.collections.List;
 public class DataObjectTesterParameter {
     private Class objectClass;
     private Object value;
-    
+
     public DataObjectTesterParameter(Class clazz, Object value) {
         this.objectClass = clazz;
         this.value = value;
     }
-    
+
     public Class getObjectClass() {
         return this.objectClass;
     }
-    
+
     public Object getValue() {
         return this.value;
     }
@@ -77,16 +77,14 @@ public class DataObjectTesterParameter {
     }
 
     private String valueToString(Object o) {
-        
-        System.out.println("Object class:  " + o.getClass().getCanonicalName());
-       
+
         StringBuilder sb = new StringBuilder();
-        
+
         if (o instanceof Iterable) {
             Iterator<Object> i = ((Iterable<Object>) o).iterator();
             return iterableToString(i);
         }
-        
+
         if (o instanceof Map) {
             Map map = (Map) o;
             sb.append("[");
@@ -107,30 +105,41 @@ public class DataObjectTesterParameter {
             sb.append("]");
             return sb.toString();
         }
-        
+
         if (null != o && o.getClass().isArray()) {
-            System.out.println("Got Here!");
-           ArrayList l = new ArrayList(Arrays.asList(o));
-           Iterator<Object> i = l.iterator();
-           return iterableToString(i);
+            ArrayList l = new ArrayList(Arrays.asList(o));
+            Iterator<Object> i = l.iterator();
+            if (null != i) {
+                return iterableToString(i);
+            }
         }
-        
+
+        if (null != o) {
+            sb.append(o.toString());
+        }
+
         return sb.toString();
     }
-    
+
     private String iterableToString(Iterator i) {
-        
+
         StringBuilder sb = new StringBuilder();
-        sb.append("[");        
+        sb.append("[");
+        Object o;
         
         if (i.hasNext()) {
-            sb.append(i.next().toString());
+            o= i.next();
+            if (null != o) {
+                sb.append(o.toString());
+            } else {
+                sb.append("null");
+            }
         }
         while (i.hasNext()) {
             sb.append(", " + i.next().toString());
         }
         sb.append("]");
-        
-        return sb.toString();   
+
+        return sb.toString();
     }
 }

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/PrimitiveValueLists.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/PrimitiveValueLists.java
@@ -1,0 +1,23 @@
+package com.dtcc.workflowmetrics.test.util;
+
+public class PrimitiveValueLists {
+
+    public static final byte[] bytes = new byte[] { Byte.MIN_VALUE, Byte.MAX_VALUE / 4, Byte.MAX_VALUE / 2,
+            (byte) ((Byte.MAX_VALUE / 4) * 3), Byte.MAX_VALUE };
+    public static final char[] chars = new char[] { Character.MIN_VALUE, (char) (Character.MAX_VALUE / 4),
+            (char) Character.MAX_VALUE / 2, 'a', 'b', 'c', '0', '1', '2', (char) ((Character.MAX_VALUE / 4) * 3),
+            Character.MAX_VALUE };
+    public static final short[] shorts = new short[] { Short.MIN_VALUE, -5, 0, 5, Short.MAX_VALUE };
+    public static final int[] integers = new int[] { Integer.MIN_VALUE, -5, 0, 5, Integer.MAX_VALUE };
+    public static final long[] longs = new long[] { Long.MIN_VALUE, -5l, 0l, 5l, Long.MAX_VALUE };
+    public static final float[] floats = new float[] { Float.MIN_VALUE, (float) (Math.PI * -1), (1 / 7) * -1, -1, 0, 1,
+            (1 / 7), (float) Math.PI, Float.MAX_VALUE };
+    public static final double[] doubles = new double[] { Double.MIN_VALUE, (double) (Math.PI * -1), (1 / 7) * -1, -1,
+            0, 1, (1 / 7), (double) Math.PI, Double.MAX_VALUE };
+    public static final String[] strings = new String[] { StringValueProviderHelper.generateStringOfLength(-1),
+            StringValueProviderHelper.generateStringOfLength(0), StringValueProviderHelper.generateStringOfLength(1000),
+            StringValueProviderHelper.generateStringOfLength(10000),
+            StringValueProviderHelper.generateStringOfLength(1073741824 / 2) 
+            };
+
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/PrimitiveValueLists.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/PrimitiveValueLists.java
@@ -16,8 +16,8 @@ public class PrimitiveValueLists {
             0, 1, (1 / 7), (double) Math.PI, Double.MAX_VALUE };
     public static final String[] strings = new String[] { StringValueProviderHelper.generateStringOfLength(-1),
             StringValueProviderHelper.generateStringOfLength(0), StringValueProviderHelper.generateStringOfLength(1000),
-            StringValueProviderHelper.generateStringOfLength(10000),
-            StringValueProviderHelper.generateStringOfLength(1073741824 / 2) 
+            StringValueProviderHelper.generateStringOfLength(10000)
+            // StringValueProviderHelper.generateStringOfLength(1073741824 / 2) 
             };
 
 }

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/StringValueProviderHelper.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/StringValueProviderHelper.java
@@ -1,0 +1,49 @@
+package com.dtcc.workflowmetrics.test.util;
+
+import java.util.Random;
+
+public class StringValueProviderHelper {
+
+    protected static final String generateStringOfLength(long stringLength) {
+
+        if (0 > stringLength) {
+            return null;
+        }
+
+        if (0 == stringLength) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append((char) 0);
+        long characterCount = 1;
+        long characterInterval = 1;
+        if (stringLength < Character.MAX_VALUE) {
+            characterInterval = (int) Character.MAX_VALUE / stringLength - 1;
+        }
+        while (characterCount < stringLength) {
+            sb.append((char) ((characterCount * characterInterval) % Character.MAX_VALUE));
+            characterCount++;
+        }
+
+        return sb.toString();
+    }
+
+    private static final Boolean isLetterOrDigit(int c) {
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+            return true;
+        }
+
+        // check if ch is a digit
+        if (c >= '0' && c <= '9') {
+            return true;
+        }
+        
+        // check if ch is a whitespace
+        if ((c == ' ') || (c == '\n') || (c == '\t')) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/TempClassUnderTest.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/TempClassUnderTest.java
@@ -10,4 +10,8 @@ public class TempClassUnderTest {
     public TempClassUnderTest(int firstArgument) {
         
     }
+    
+    public TempClassUnderTest(int firstArgument, String secondArgument) {
+        
+    }
 }

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/TempClassUnderTest.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/TempClassUnderTest.java
@@ -1,0 +1,13 @@
+package com.dtcc.workflowmetrics.test.util;
+
+public class TempClassUnderTest {
+    
+    
+    public TempClassUnderTest() {
+        
+    }
+    
+    public TempClassUnderTest(int firstArgument) {
+        
+    }
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/TempDataObjectTesterTest.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/TempDataObjectTesterTest.java
@@ -1,0 +1,50 @@
+package com.dtcc.workflowmetrics.test.util;
+
+import static org.junit.Assert.*;
+
+import java.util.function.Supplier;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TempDataObjectTesterTest {
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testTestPassedClassesStringArray() {
+        DataObjectTester dot = new DataObjectTester();
+
+        dot.testPassedClasses(new String[] { "com.dtcc.workflowmetrics.test.util.TempClassUnderTest" });
+    }
+
+    @Test
+    public void testTestPassedClassesArrayListOfString() {
+        DataObjectTester dot = new DataObjectTester();
+
+        dot.testPassedClasses(new String[] { "com.dtcc.workflowmetrics.test.util.TempClassUnderTest" });
+    }
+
+    @Test
+    public void WorkingTest() {
+
+    }
+
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/ValueProviders.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/ValueProviders.java
@@ -58,6 +58,10 @@ public class ValueProviders {
         if (null == provider) {
             provider = defaultValueProviders.get(c);
         }
+        
+        if (null == provider) {
+            throw new RuntimeException("Class " + c.getCanonicalName() + " does not have a supported provider, and can't be supplied by the object test framework");
+        }
         return provider;
     }
 

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/ValueProviders.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/test/util/ValueProviders.java
@@ -1,0 +1,64 @@
+package com.dtcc.workflowmetrics.test.util;
+
+import java.util.HashMap;
+import java.util.function.Supplier;
+
+/**
+ * This class provides a set of value generators for Java primitives and some
+ * "standard" classes (i.e. String, ...) to be used in both constructors for
+ * objects, and in setters.
+ * 
+ * @author dan.michaelis
+ *
+ */
+public class ValueProviders {
+
+    private static HashMap<Class<?>, Supplier<?>> defaultValueProviders = new HashMap<Class<?>, Supplier<?>>();
+    private HashMap<Class<?>, Supplier<?>> customValueProviders = new HashMap<Class<?>, Supplier<?>>();
+
+    public ValueProviders() {
+        if (defaultValueProviders.isEmpty()) {
+            defaultValueProviders.put(byte.class, () -> {
+                return PrimitiveValueLists.bytes;
+            });
+            defaultValueProviders.put(char.class, () -> {
+                return PrimitiveValueLists.chars;
+            });
+            defaultValueProviders.put(short.class, () -> {
+                return PrimitiveValueLists.shorts;
+            });
+            defaultValueProviders.put(int.class, () -> {
+                return PrimitiveValueLists.integers;
+            });
+            defaultValueProviders.put(long.class, () -> {
+                return PrimitiveValueLists.longs;
+            });
+            defaultValueProviders.put(float.class, () -> {
+                return PrimitiveValueLists.floats;
+            });
+            defaultValueProviders.put(double.class, () -> {
+                return PrimitiveValueLists.doubles;
+            });
+            defaultValueProviders.put(String.class, () -> {
+                return PrimitiveValueLists.strings;
+            });
+        }
+    }
+
+    public void addCustomProvider(Class<?> clazz, Supplier<?> supplier) {
+        customValueProviders.put(clazz, supplier);
+    }
+
+    public void setCustomProviders(HashMap<Class<?>, Supplier<?>> providers) {
+        this.customValueProviders = providers;
+    }
+
+    public Supplier<?> getProvider(Class c) {
+        Supplier<?> provider = customValueProviders.get(c);
+        if (null == provider) {
+            provider = defaultValueProviders.get(c);
+        }
+        return provider;
+    }
+
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/util/simulator/workflows/WorkflowEntityTest.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/util/simulator/workflows/WorkflowEntityTest.java
@@ -1,0 +1,20 @@
+package com.dtcc.workflowmetrics.util.simulator.workflows;
+
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.dtcc.workflowmetrics.dao.EventUserDao;
+import com.dtcc.workflowmetrics.entity.EventUser;
+
+public class WorkflowEntityTest {
+
+	@RunWith(SpringRunner.class)
+	@SpringBootTest
+	public class WorkflowGeneratorTests {
+	}
+}

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/util/simulator/workflows/WorkflowGeneratorTests.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/util/simulator/workflows/WorkflowGeneratorTests.java
@@ -53,7 +53,7 @@ public class WorkflowGeneratorTests {
     	eventUser.setUserID(1011);
     	eventUser.setEmailId("jiniya.ghosh@perficient.com");
     	eventUser.setUserName("Jiniya");
-    	eventUser.setSourceSystem("Jira");
+    	eventUser.setSourceSystem(12);
     	Date dt = new Date();
     	eventUser.setLastUpdateDate(dt.getTime());
     	

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/util/simulator/workflows/WorkflowGeneratorTests.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/util/simulator/workflows/WorkflowGeneratorTests.java
@@ -50,7 +50,7 @@ public class WorkflowGeneratorTests {
 			
     	EventUser eventUser = new EventUser();
     	
-    	eventUser.setUserID(1011);
+    	eventUser.setId("jiniya.ghosh@perficient.com");
     	eventUser.setEmailId("jiniya.ghosh@perficient.com");
     	eventUser.setUserName("Jiniya");
     	eventUser.setSourceSystem(12);
@@ -59,7 +59,7 @@ public class WorkflowGeneratorTests {
     	
     	EventUser storedEventUser = eventUserDao.save(eventUser);
     	
-    	assertEquals(storedEventUser.getUserID(), eventUser.getUserID());
+    	assertEquals(storedEventUser.getId(), eventUser.getId());
     }
 
     @Test
@@ -68,7 +68,7 @@ public class WorkflowGeneratorTests {
 			
     	EventUserCustomField eventUserCustFld = new EventUserCustomField();
     	
-    	eventUserCustFld.setUserID(1011);
+    	eventUserCustFld.setUserID("jiniya.ghosh@perficient.com");
     	eventUserCustFld.setSourceSystem(1);
     	eventUserCustFld.setFieldName("ABC");
     	eventUserCustFld.setFieldDatatype("String");
@@ -77,6 +77,20 @@ public class WorkflowGeneratorTests {
     	eventUserCustFld.setCreateDate(dt.getTime());
     	
     	EventUserCustomField storedEventUserCustFld = eventUserCustomFieldDao.save(eventUserCustFld);
+    	
+    	assertEquals(storedEventUserCustFld.getUserID(), eventUserCustFld.getUserID());
+
+    	eventUserCustFld = new EventUserCustomField();
+    	
+    	eventUserCustFld.setUserID("jiniya.ghosh@perficient.com");
+    	eventUserCustFld.setSourceSystem(1);
+    	eventUserCustFld.setFieldName("ABC");
+    	eventUserCustFld.setFieldDatatype("String");
+       	eventUserCustFld.setFieldValue("BCDValue");
+        dt = new Date();
+    	eventUserCustFld.setCreateDate(dt.getTime());
+    	
+    	storedEventUserCustFld = eventUserCustomFieldDao.save(eventUserCustFld);
     	
     	assertEquals(storedEventUserCustFld.getUserID(), eventUserCustFld.getUserID());
     }

--- a/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/util/simulator/workflows/WorkflowGeneratorTests.java
+++ b/workflowmetrics/src/test/java/com/dtcc/workflowmetrics/util/simulator/workflows/WorkflowGeneratorTests.java
@@ -2,21 +2,32 @@ package com.dtcc.workflowmetrics.util.simulator.workflows;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Date;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.dtcc.workflowmetrics.dao.EventUserCustomFieldDao;
+import com.dtcc.workflowmetrics.dao.EventUserDao;
+import com.dtcc.workflowmetrics.entity.EventUser;
+import com.dtcc.workflowmetrics.entity.EventUserCustomField;
 import com.dtcc.workflowmetrics.metricsitems.jira.IssueHistory;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class WorkflowGeneratorTests {
 
-    @Test
+	@Autowired
+	EventUserDao eventUserDao;
+
+	@Autowired
+	EventUserCustomFieldDao eventUserCustomFieldDao;
+	
+	
+	@Test
     public void generateTestWorkflow() {
         int maxIssues = 5;
         int currentIssue = 0;
@@ -32,4 +43,42 @@ public class WorkflowGeneratorTests {
         }
 
     }
+    
+    @Test
+    public void generateTestEventUserEntity() {
+    	
+			
+    	EventUser eventUser = new EventUser();
+    	
+    	eventUser.setUserID(1011);
+    	eventUser.setEmailId("jiniya.ghosh@perficient.com");
+    	eventUser.setUserName("Jiniya");
+    	eventUser.setSourceSystem("Jira");
+    	Date dt = new Date();
+    	eventUser.setLastUpdateDate(dt.getTime());
+    	
+    	EventUser storedEventUser = eventUserDao.save(eventUser);
+    	
+    	assertEquals(storedEventUser.getUserID(), eventUser.getUserID());
+    }
+
+    @Test
+    public void generateTestEventUserCustomFieldEntity() {
+    	
+			
+    	EventUserCustomField eventUserCustFld = new EventUserCustomField();
+    	
+    	eventUserCustFld.setUserID(1011);
+    	eventUserCustFld.setSourceSystem(1);
+    	eventUserCustFld.setFieldName("ABC");
+    	eventUserCustFld.setFieldDatatype("String");
+       	eventUserCustFld.setFieldValue("ABCValue");
+        Date dt = new Date();
+    	eventUserCustFld.setCreateDate(dt.getTime());
+    	
+    	EventUserCustomField storedEventUserCustFld = eventUserCustomFieldDao.save(eventUserCustFld);
+    	
+    	assertEquals(storedEventUserCustFld.getUserID(), eventUserCustFld.getUserID());
+    }
+
 }


### PR DESCRIPTION
•	Capture of the Metrics_Item and appropriate population of unique ID for the table
•	Capture of the configurable field data in an appropriate manner
o	If the data is for a user, we should see the user name in the value field, and the appropriate information in the rest of the fields in the data table
o	If the data is for a “standard” configurable field, the value field in the database should contain the value of the configurable field
o	If the data field is either a single long string, or is an array, the value field should contain the JSON representation of that field
•	Capture of the item status data, with the join to the metrics_item table appropriately populated
•	Capture of the transition_duration data, with the join to the metrics_item table appropriately populated
o	Must include the correct calculation of the duration
o	Must allow for transition between any statuses and still calculate duration appropriately
•	Creation of a status reference value if the transmitted status doesn’t exist in the status reference table
